### PR TITLE
Chore/update serialization classes

### DIFF
--- a/kiota_abstractions/serialization/__init__.py
+++ b/kiota_abstractions/serialization/__init__.py
@@ -4,6 +4,7 @@ from .parsable_factory import ParsableFactory
 from .parse_node import ParseNode
 from .parse_node_factory import ParseNodeFactory
 from .parse_node_factory_registry import ParseNodeFactoryRegistry
+from .parse_node_helper import ParseNodeHelper
 from .parse_node_proxy_factory import ParseNodeProxyFactory
 from .serialization_writer import SerializationWriter
 from .serialization_writer_factory import SerializationWriterFactory

--- a/kiota_abstractions/serialization/additional_data_holder.py
+++ b/kiota_abstractions/serialization/additional_data_holder.py
@@ -1,17 +1,10 @@
-from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 from typing import Any, Dict
 
 
-class AdditionalDataHolder(ABC):
+@dataclass
+class AdditionalDataHolder:
     """Defines a contract for models that can hold additional data besides the described properties.
     """
-
-    @property
-    @abstractmethod
-    def additional_data(self) -> Dict[str, Any]:
-        """Stores the additional data for this object that did not belong to the properties.
-
-        Returns:
-            Dict[str, Any]: The additional data for this object
-        """
-        pass
+    # Stores the additional data for this object that did not belong to the properties.
+    additional_data: Dict[str, Any] = field(default_factory=dict)

--- a/kiota_abstractions/serialization/parsable.py
+++ b/kiota_abstractions/serialization/parsable.py
@@ -14,7 +14,7 @@ class Parsable(ABC):
     """
     Defines a serializable model object.
     """
-    
+
     @abstractmethod
     def get_field_deserializers(self) -> Dict[str, Callable[['ParseNode'], None]]:
         """Gets the deserialization information for this object.

--- a/kiota_abstractions/serialization/parsable.py
+++ b/kiota_abstractions/serialization/parsable.py
@@ -1,6 +1,6 @@
-from dataclasses import asdict, dataclass
-from json import dumps
-from typing import TYPE_CHECKING, Any, Callable, Dict, Protocol, TypeVar
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, Dict, TypeVar
 
 T = TypeVar("T")
 
@@ -10,11 +10,12 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class Parsable(Protocol):
+class Parsable(ABC):
     """
     Defines a serializable model object.
     """
-
+    
+    @abstractmethod
     def get_field_deserializers(self) -> Dict[str, Callable[['ParseNode'], None]]:
         """Gets the deserialization information for this object.
 
@@ -22,12 +23,13 @@ class Parsable(Protocol):
             Dict[str, Callable[[ParseNode], None]]: The deserialization information for this
             object where each entry is a property key with its deserialization callback.
         """
-        ...
+        pass
 
+    @abstractmethod
     def serialize(self, writer: 'SerializationWriter') -> None:
         """Writes the objects properties to the current writer.
 
         Args:
             writer (SerializationWriter): The writer to write to.
         """
-        ...
+        pass

--- a/kiota_abstractions/serialization/parse_node_helper.py
+++ b/kiota_abstractions/serialization/parse_node_helper.py
@@ -8,7 +8,7 @@ class ParseNodeHelper:
     @staticmethod
     def merge_deserializers_for_intersection_wrapper(
         *targets: Parsable
-        ) -> Dict[str, Callable[[ParseNode], None]]:
+    ) -> Dict[str, Callable[[ParseNode], None]]:
         """Merges a collection of parsable field deserializers into a single collection.
 
         Args:

--- a/kiota_abstractions/serialization/parse_node_helper.py
+++ b/kiota_abstractions/serialization/parse_node_helper.py
@@ -19,10 +19,8 @@ class ParseNodeHelper:
         Returns:
             Dict[str, Callable[[ParseNode], None]]:
         """
-        if targets is None:
-            raise ValueError("targets cannot be None")
         if not targets:
-            raise ValueError("At least one target must be provided.")
+            raise TypeError("targets cannot be null.")
 
         merged_deserializers = {}
         for target in targets:

--- a/kiota_abstractions/serialization/parse_node_helper.py
+++ b/kiota_abstractions/serialization/parse_node_helper.py
@@ -1,6 +1,7 @@
-from typing import Callable, Dict, List, Tuple
+from typing import Callable, Dict, List, Tuple, TYPE_CHECKING
 
-from . import Parsable, ParseNode
+if TYPE_CHECKING:
+    from . import Parsable, ParseNode
 
 
 class ParseNodeHelper:

--- a/kiota_abstractions/serialization/parse_node_helper.py
+++ b/kiota_abstractions/serialization/parse_node_helper.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Tuple
 
 from . import Parsable, ParseNode
 
@@ -7,12 +7,12 @@ class ParseNodeHelper:
 
     @staticmethod
     def merge_deserializers_for_intersection_wrapper(
-        targets: List[Parsable]
-    ) -> Dict[str, Callable[[ParseNode], None]]:
+        *targets: Parsable
+        ) -> Dict[str, Callable[[ParseNode], None]]:
         """Merges a collection of parsable field deserializers into a single collection.
 
         Args:
-            targets (List[Parsable]):
+            targets (tuple[Parsable, ...]):
 
         Returns:
             Dict[str, Callable[[ParseNode], None]]:

--- a/kiota_abstractions/serialization/parse_node_helper.py
+++ b/kiota_abstractions/serialization/parse_node_helper.py
@@ -1,4 +1,5 @@
-from typing import Callable, Dict, List, Tuple, TYPE_CHECKING
+from __future__ import annotations
+from typing import Callable, Dict, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from . import Parsable, ParseNode


### PR DESCRIPTION
part of https://github.com/microsoft/kiota/issues/1813

- Pass targets as variable length arguments instead of array.
- Update structure of base serialization classes to fix typing errors.