### PR TITLE
Run the tests in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Static type checking with Mypy
         run: |
           mypy kiota_abstractions
+      - name: Run the tests
+        run: |
+          pytest
 
   publish:
     name: Publish distribution to PyPI


### PR DESCRIPTION
The tests are passing, but I think it's good to ensure the quality of contributions to always run the tests in CI.