### PR TITLE
chore: use staticmethod decorator on get_key()

### DIFF
--- a/kiota_abstractions/request_option.py
+++ b/kiota_abstractions/request_option.py
@@ -5,11 +5,11 @@ class RequestOption(ABC):
     """Represents a request option
     """
 
+    @staticmethod
     @abstractmethod
-    def get_key(self) -> str:
+    def get_key() -> str:
         """Gets the option key for when adding it to a request. Must be unique
 
         Returns:
             str: The option key
         """
-        pass


### PR DESCRIPTION
The usage of RequestOptions in [kiota http](https://github.com/microsoft/kiota-http-python/blob/main/kiota_http/kiota_client_factory.py\#L101-L119) is of the signature of a staticmethod. This update ensures that the abstractmethod is exposed as an abstract and static method

https://github.com/microsoft/kiota-http-python/blob/0064ed6039f129039fb5e391e7aaa2d2f73d4ea4/kiota_http/kiota_client_factory.py#L101-L119