### PR TITLE
chore: update the BackingStoreFactorySingleton class

### DIFF
--- a/kiota_abstractions/request_option.py
+++ b/kiota_abstractions/request_option.py
@@ -5,8 +5,9 @@ class RequestOption(ABC):
     """Represents a request option
     """
 
+    @staticmethod
     @abstractmethod
-    def get_key(self) -> str:
+    def get_key() -> str:
         """Gets the option key for when adding it to a request. Must be unique
 
         Returns:

--- a/kiota_abstractions/store/__init__.py
+++ b/kiota_abstractions/store/__init__.py
@@ -1,4 +1,4 @@
-from .backed_model import BackingStore
+from .backed_model import BackedModel
 from .backing_store import BackingStore
 from .backing_store_factory import BackingStoreFactory
 from .backing_store_factory_singleton import BackingStoreFactorySingleton

--- a/kiota_abstractions/store/backing_store.py
+++ b/kiota_abstractions/store/backing_store.py
@@ -1,10 +1,10 @@
 from abc import ABC, abstractmethod
-from typing import Any, Callable, List, Optional, Tuple, TypeVar
+from typing import Any, Callable, Generic, List, Optional, Tuple, TypeVar
 
 T = TypeVar("T")
 
 
-class BackingStore(ABC):
+class BackingStore(ABC, Generic[T]):
     """Stores model information in a different location than the object properties.
     Implementations can provide dirty tracking capabilities, caching capabilities
     or integration with 3rd party stores
@@ -80,8 +80,7 @@ class BackingStore(ABC):
 
     @abstractmethod
     def clear(self) -> None:
-        """Clears the data stored in the backing store. Doesn't trigger any subscription.
-        """
+        """Clears the data stored in the backing store. Doesn't trigger any subscription."""
         pass
 
     @abstractmethod
@@ -95,7 +94,7 @@ class BackingStore(ABC):
         pass
 
     @abstractmethod
-    def set_is_initialization_completed(self, bool) -> None:
+    def set_is_initialization_completed(self, completed) -> None:
         """Sets whether the initialization of the object and/or the initial deserialization has been
         completed to track whether objects have changed.
         """
@@ -112,7 +111,7 @@ class BackingStore(ABC):
         pass
 
     @abstractmethod
-    def set_return_only_changed_values(self, bool) -> None:
+    def set_return_only_changed_values(self, changed) -> None:
         """Sets whether to return only values that have changed since the initialization of the
         object when calling the Get and Enumerate methods.
 

--- a/kiota_abstractions/store/backing_store_factory_singleton.py
+++ b/kiota_abstractions/store/backing_store_factory_singleton.py
@@ -1,7 +1,51 @@
-from .backing_store_factory import BackingStoreFactory
-from .in_memory_backing_store_factory import InMemoryBackingStoreFactory
+from typing import Self
+
+from kiota_abstractions.store.backing_store_factory import BackingStoreFactory
+from kiota_abstractions.store.in_memory_backing_store_factory import InMemoryBackingStoreFactory
 
 
-class BackingStoreFactorySingleton():
+class BackingStoreFactorySingleton:
+    """
+    Ensures that there is only a single instance of a Backing Store Factory.
+    """
 
-    __instance: BackingStoreFactory = InMemoryBackingStoreFactory()
+    def __new__(cls, *args, **kwargs):
+        """
+        Creates a single instance of the class during instantiation. It also
+        ensures that the backing store factory that was set in the first
+        instantion of the class will be the default during run time.
+        """
+        try:
+            bs_arg = args[0]
+        except IndexError:
+            bs_arg = kwargs.get("backing_store_factory", None)
+
+        bs_property = hasattr(cls, "backing_store_factory")
+        if not hasattr(cls, "__instance"):
+            if bs_property and isinstance(bs_arg, BackingStoreFactory):
+                cls.backing_store_factory = bs_arg
+            else:
+                # Default backing store is InMemoryBackingStoreFactory
+                cls.backing_store_factory = InMemoryBackingStoreFactory()
+            cls.__instance = super(BackingStoreFactorySingleton, cls).__new__(cls)
+        return cls.__instance
+
+    @classmethod
+    def get_instance(cls) -> Self:
+        """
+        Returns the instance of the class.
+        """
+        return cls.__instance
+
+    def __init__(self, backing_store_factory: BackingStoreFactory) -> None:
+        self._backing_store_factory = backing_store_factory
+
+    @property
+    def backing_store_factory(self) -> BackingStoreFactory:
+        """Returns the set backing store"""
+        return self._backing_store_factory
+
+    @backing_store_factory.setter
+    def backing_store_factory(self, backing_store_factory: BackingStoreFactory):
+        """Sets the backing store to the value initialized in the singleton."""
+        self._backing_store_factory = backing_store_factory

--- a/kiota_abstractions/store/backing_store_factory_singleton.py
+++ b/kiota_abstractions/store/backing_store_factory_singleton.py
@@ -1,7 +1,9 @@
-from typing import Self
+from typing_extensions import Self
 
 from kiota_abstractions.store.backing_store_factory import BackingStoreFactory
-from kiota_abstractions.store.in_memory_backing_store_factory import InMemoryBackingStoreFactory
+from kiota_abstractions.store.in_memory_backing_store_factory import (
+    InMemoryBackingStoreFactory,
+)
 
 
 class BackingStoreFactorySingleton:

--- a/kiota_abstractions/store/in_memory_backing_store.py
+++ b/kiota_abstractions/store/in_memory_backing_store.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
+from typing import Any, Callable, Dict, Generic, List, Optional, Tuple, TypeVar
 from uuid import uuid4
 
 from .backing_store import BackingStore
@@ -10,9 +10,8 @@ StoreEntry = Tuple[str, Any]
 T = TypeVar("T")
 
 
-class InMemoryBackingStore(BackingStore):
-    """In-memory implementation of the backing store. Allows for dirty tracking of changes.
-    """
+class InMemoryBackingStore(BackingStore, Generic[T]):
+    """In-memory implementation of the backing store. Allows for dirty tracking of changes."""
 
     __subscriptions: Dict[str, SubscriptionCallback] = {}
     __store: Dict[str, Tuple[bool, Any]] = {}
@@ -104,13 +103,11 @@ class InMemoryBackingStore(BackingStore):
         del self.__subscriptions[subscription_id]
 
     def clear(self) -> None:
-        """Clears the store
-        """
+        """Clears the store"""
         self.__store.clear()
 
     def get_is_initialization_completed(self) -> bool:
-        """Flag to show the initialization status of the store.
-        """
+        """Flag to show the initialization status of the store."""
         return self.__initialization_completed
 
     def set_is_initialization_completed(self, value: bool) -> None:
@@ -119,8 +116,7 @@ class InMemoryBackingStore(BackingStore):
             self.__store[key] = (not value, val[1])
 
     def get_return_only_changed_values(self) -> bool:
-        """Determines whether the backing store should only return changed values when queried.
-        """
+        """Determines whether the backing store should only return changed values when queried."""
         return self.return_only_changed_values
 
     def set_return_only_changed_values(self, value: bool) -> None:

--- a/tests/authentication/test_api_key_authentication_provider.py
+++ b/tests/authentication/test_api_key_authentication_provider.py
@@ -6,8 +6,6 @@ from kiota_abstractions.authentication import (
     AuthenticationProvider,
 )
 
-from kiota_abstractions.request_information import RequestInformation
-
 allowed_hosts = ["https://example.com"]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,19 @@
+from typing import Callable, List, Any, Tuple
 import pytest
 
 from kiota_abstractions.authentication.access_token_provider import AccessTokenProvider
-from kiota_abstractions.authentication.allowed_hosts_validator import AllowedHostsValidator
+from kiota_abstractions.authentication.allowed_hosts_validator import (
+    AllowedHostsValidator,
+)
 from kiota_abstractions.request_information import RequestInformation
+from kiota_abstractions.store import (
+    BackingStore,
+    InMemoryBackingStore,
+    BackingStoreFactory,
+)
 
 
 class MockAccessTokenProvider(AccessTokenProvider):
-
     def __init__(self):
         self.token = None
 

--- a/tests/store/test_backing_store_factory_singleton.py
+++ b/tests/store/test_backing_store_factory_singleton.py
@@ -19,7 +19,7 @@ class MockTestBackingStore(BackingStore, Generic[T]):
         self.init_complete = True
         self.return_only_changed_values = True
 
-    def get(self, key: str) -> Any | None:
+    def get(self, key: str) -> Any:
         return self.store.get(key, None)
 
     def set(self, key: str, value: Any) -> None:

--- a/tests/store/test_backing_store_factory_singleton.py
+++ b/tests/store/test_backing_store_factory_singleton.py
@@ -1,0 +1,88 @@
+from typing import Any, Callable, TypeVar, Generic, List, Tuple
+import pytest
+
+from kiota_abstractions.store import (
+    BackingStoreFactorySingleton,
+    InMemoryBackingStoreFactory,
+)
+from kiota_abstractions.store.backing_store import BackingStore
+from kiota_abstractions.store.backing_store_factory import BackingStoreFactory
+from kiota_abstractions.store.in_memory_backing_store import InMemoryBackingStore
+
+T = TypeVar("T")
+
+
+class MockTestBackingStore(BackingStore, Generic[T]):
+    def __init__(self) -> None:
+        self.store = {}
+        self.subscriptions = {}
+        self.init_complete = True
+        self.return_only_changed_values = True
+
+    def get(self, key: str) -> Any | None:
+        return self.store.get(key, None)
+
+    def set(self, key: str, value: Any) -> None:
+        self.store.update({key: value})
+
+    def clear(self) -> None:
+        self.store.clear()
+
+    def enumerate_(self) -> List[Tuple[str, Any]]:
+        return list(self.store.values())
+
+    def enumerate_keys_for_values_changed_to_null(self) -> List[str]:
+        return list(k for k, v in self.store if v is None)
+
+    def subscribe(
+        self, callback: Callable[[str, Any, Any], None], subscription_id: str | None
+    ) -> str:
+        if subscription_id:
+            self.subscriptions.update({subscription_id: callback})
+        return subscription_id or ""
+
+    def unsubscribe(self, subscription_id: str) -> None:
+        self.subscriptions.pop(subscription_id)
+
+    def get_is_initialization_completed(self) -> bool:
+        return self.init_complete
+
+    def set_is_initialization_completed(self, completed) -> None:
+        self.init_complete = completed
+
+    def get_return_only_changed_values(self) -> bool:
+        return self.return_only_changed_values
+
+    def set_return_only_changed_values(self, changed) -> None:
+        self.return_only_changed_values = changed
+
+
+class MockTestBackingStoreFactory(BackingStoreFactory):
+    def create_backing_store(self) -> BackingStore:
+        return MockTestBackingStore()
+
+
+@pytest.fixture
+def inmemory_backing_store():
+    return InMemoryBackingStore()
+
+
+def test_backing_store_factory_default():
+    bsf = BackingStoreFactorySingleton(backing_store_factory=None)
+    assert isinstance(bsf.backing_store_factory, InMemoryBackingStoreFactory)
+
+
+def test_backing_store_factory_is_singleton():
+    """
+    Test that the backing store factory that was initialized with the backing
+    store singleton is not overridden when you initialize backing store factory
+    singleton with a different backing store factory at runtime.
+    """
+    bsf = BackingStoreFactorySingleton(
+        backing_store_factory=MockTestBackingStoreFactory()
+    )
+    bsf2 = BackingStoreFactorySingleton(
+        backing_store_factory=InMemoryBackingStoreFactory()
+    )
+    assert bsf.get_instance() == bsf2.get_instance()
+    assert bsf.backing_store_factory is bsf2.backing_store_factory

--- a/tests/store/test_backing_store_factory_singleton.py
+++ b/tests/store/test_backing_store_factory_singleton.py
@@ -35,7 +35,7 @@ class MockTestBackingStore(BackingStore, Generic[T]):
         return list(k for k, v in self.store if v is None)
 
     def subscribe(
-        self, callback: Callable[[str, Any, Any], None], subscription_id: str | None
+        self, callback: Callable[[str, Any, Any], None], subscription_id: str
     ) -> str:
         if subscription_id:
             self.subscriptions.update({subscription_id: callback})

--- a/tests/store/test_backing_store_factory_singleton.py
+++ b/tests/store/test_backing_store_factory_singleton.py
@@ -62,11 +62,6 @@ class MockTestBackingStoreFactory(BackingStoreFactory):
         return MockTestBackingStore()
 
 
-@pytest.fixture
-def inmemory_backing_store():
-    return InMemoryBackingStore()
-
-
 def test_backing_store_factory_default():
     bsf = BackingStoreFactorySingleton(backing_store_factory=None)
     assert isinstance(bsf.backing_store_factory, InMemoryBackingStoreFactory)


### PR DESCRIPTION
Ensure that the backing store factory that was set in the first instantiation of the class will be the default during run time.

This changes how the BackingStoreFactory is set [here](https://github.com/microsoft/kiota-http-python/blob/be3f79c61932eddf862519f58ed5d460d2648955/kiota_http/httpx_request_adapter.py#L265-L266):

```python
# from this
if backing_store_factory:
  BackingStoreFactorySingleton.__instance = backing_store_factory # directly accessing an internal, protected member

# to this
if backing_store_factory:
  BackingStoreFactorySingleton(backing_store_factory=backing_store_factory)

# or just this as it will default to InMemoryBackingStoreFactory
BackingStoreFactorySingleton(backing_store_factory=backing_store_factory)
```

I would like some more insight on why this has to be a singleton. This update changes the `BackingStoreFactorySingleton` API and I would love knowing I'm not breaking this upstream in the pipeline.