### PR TITLE
Chore/backing store support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [0.7.0] - 2023-06-27
+
+### Added
+- Enable backing store for Python.
+
 ## [0.6.0] - 2023-06-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.1] - 2023-07-27
+## [0.7.0] - 2023-07-27
 
 ### Added
 - Added an abstract translator method that should convert a `RequestInformation` object into the native client HTTP request object.

--- a/kiota_abstractions/_version.py
+++ b/kiota_abstractions/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = "0.6.0"
+VERSION: str = "0.7.0"

--- a/kiota_abstractions/_version.py
+++ b/kiota_abstractions/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = "0.6.1"
+VERSION: str = "0.7.0"

--- a/kiota_abstractions/request_information.py
+++ b/kiota_abstractions/request_information.py
@@ -158,9 +158,9 @@ class RequestInformation():
         writer = self._get_serialization_writer(request_adapter, content_type, values)
 
         if isinstance(values, list):
-            writer.writer = writer.write_collection_of_object_values(None, values)
+            writer.write_collection_of_object_values(None, values)
         else:
-            writer.writer = writer.write_object_value(None, values)
+            writer.write_object_value(None, values)
 
         self._set_content_and_content_type_header(writer, content_type)
 

--- a/kiota_abstractions/serialization/parse_node.py
+++ b/kiota_abstractions/serialization/parse_node.py
@@ -174,8 +174,9 @@ class ParseNode(ABC):
         """
         pass
 
+    @property
     @abstractmethod
-    def get_on_before_assign_field_values(self) -> Callable[[Parsable], None]:
+    def on_before_assign_field_values(self) -> Callable[[Parsable], None]:
         """Gets the callback called before the node is deserialized.
 
         Returns:
@@ -183,31 +184,33 @@ class ParseNode(ABC):
         """
         pass
 
+    @on_before_assign_field_values.setter
     @abstractmethod
-    def get_on_after_assign_field_values(self) -> Optional[Callable[[Parsable], None]]:
-        """Gets the callback called before the node is deserialized.
-
-        Returns:
-            Callable[[Parsable], None]: the callback called before the node is deserialized.
-        """
-        pass
-
-    @abstractmethod
-    def set_on_before_assign_field_values(self, value: Callable[[Parsable], None]) -> None:
+    def on_before_assign_field_values(self) -> Optional[Callable[[Parsable], None]]:
         """Sets the callback called before the node is deserialized.
+
+        Returns:
+            Callable[[Parsable], None]: the callback called before the node is deserialized.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def on_after_assign_field_values(self) -> Optional[Callable[[Parsable], None]]:
+        """Gets the callback called after the node is deserialized.
+
+        Returns:
+            Callable[[Parsable], None]: the callback called before the node is deserialized.
+        """
+        pass
+
+    @on_after_assign_field_values.setter
+    @abstractmethod
+    def on_after_assign_field_values(self, value: Callable[[Parsable], None]) -> None:
+        """Sets the callback after before the node is deserialized.
 
         Args:
             value (Callable[[Parsable], None]): the callback called before the node is
-            deserialized.
-        """
-        pass
-
-    @abstractmethod
-    def set_on_after_assign_field_values(self, value: Callable[[Parsable], None]) -> None:
-        """Sets the callback called after the node is deserialized.
-
-        Args:
-            value (Callable[[Parsable], None]): the callback called after the node is
             deserialized.
         """
         pass

--- a/kiota_abstractions/serialization/parse_node.py
+++ b/kiota_abstractions/serialization/parse_node.py
@@ -210,7 +210,7 @@ class ParseNode(ABC):
         """Sets the callback called after the node is deserialized.
 
         Args:
-            value (Callable[[Parsable], None]): the callback called before the node is
+            value (Callable[[Parsable], None]): the callback called after the node is
             deserialized.
         """
         pass

--- a/kiota_abstractions/serialization/parse_node.py
+++ b/kiota_abstractions/serialization/parse_node.py
@@ -207,7 +207,7 @@ class ParseNode(ABC):
     @on_after_assign_field_values.setter
     @abstractmethod
     def on_after_assign_field_values(self, value: Callable[[Parsable], None]) -> None:
-        """Sets the callback after before the node is deserialized.
+        """Sets the callback called after the node is deserialized.
 
         Args:
             value (Callable[[Parsable], None]): the callback called before the node is

--- a/kiota_abstractions/serialization/parse_node.py
+++ b/kiota_abstractions/serialization/parse_node.py
@@ -186,11 +186,12 @@ class ParseNode(ABC):
 
     @on_before_assign_field_values.setter
     @abstractmethod
-    def on_before_assign_field_values(self) -> Optional[Callable[[Parsable], None]]:
+    def on_before_assign_field_values(self, value: Callable[[Parsable], None]) -> None:
         """Sets the callback called before the node is deserialized.
 
-        Returns:
-            Callable[[Parsable], None]: the callback called before the node is deserialized.
+        Args:
+            value (Callable[[Parsable], None]): the callback called before the node is
+            deserialized.
         """
         pass
 

--- a/kiota_abstractions/serialization/serialization_writer.py
+++ b/kiota_abstractions/serialization/serialization_writer.py
@@ -206,8 +206,9 @@ class SerializationWriter(ABC):
         """
         pass
 
+    @property
     @abstractmethod
-    def get_on_before_object_serialization(self) -> Optional[Callable[[Parsable], None]]:
+    def on_before_object_serialization(self) -> Optional[Callable[[Parsable], None]]:
         """Gets the callback called before the object gets serialized.
 
         Returns:
@@ -216,8 +217,20 @@ class SerializationWriter(ABC):
         """
         pass
 
+    @on_before_object_serialization.setter
     @abstractmethod
-    def get_on_after_object_serialization(self) -> Optional[Callable[[Parsable], None]]:
+    def on_before_object_serialization(self, value: Optional[Callable[[Parsable], None]]) -> None:
+        """Sets the callback called before the objects gets serialized.
+
+        Args:
+            value (Optional[Callable[[Parsable], None]]): the callback called before the objects
+            gets serialized.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def on_after_object_serialization(self) -> Optional[Callable[[Parsable], None]]:
         """Gets the callback called after the object gets serialized.
 
         Returns:
@@ -226,8 +239,20 @@ class SerializationWriter(ABC):
         """
         pass
 
+    @on_after_object_serialization.setter
     @abstractmethod
-    def get_on_start_object_serialization(
+    def on_after_object_serialization(self, value: Optional[Callable[[Parsable], None]]) -> None:
+        """Sets the callback called after the objects gets serialized.
+
+        Args:
+            value (Optional[Callable[[Parsable], None]]): the callback called after the objects
+            gets serialized.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def on_start_object_serialization(
         self
     ) -> Optional[Callable[[Parsable, SerializationWriter], None]]:
         """Gets the callback called right after the serialization process starts.
@@ -238,32 +263,9 @@ class SerializationWriter(ABC):
         """
         pass
 
+    @on_start_object_serialization.setter
     @abstractmethod
-    def set_on_before_object_serialization(
-        self, value: Optional[Callable[[Parsable], None]]
-    ) -> None:
-        """Sets the callback called before the objects gets serialized.
-
-        Args:
-            value (Optional[Callable[[Parsable], None]]): the callback called before the objects
-            gets serialized.
-        """
-        pass
-
-    @abstractmethod
-    def set_on_after_object_serialization(
-        self, value: Optional[Callable[[Parsable], None]]
-    ) -> None:
-        """Sets the callback called after the objects gets serialized.
-
-        Args:
-            value (Optional[Callable[[Parsable], None]]): the callback called after the objects
-            gets serialized.
-        """
-        pass
-
-    @abstractmethod
-    def set_on_start_object_serialization(
+    def on_start_object_serialization(
         self, value: Optional[Callable[[Parsable, SerializationWriter], None]]
     ) -> None:
         """Sets the callback called right after the serialization process starts.

--- a/kiota_abstractions/serialization/serialization_writer_proxy_factory.py
+++ b/kiota_abstractions/serialization/serialization_writer_proxy_factory.py
@@ -32,6 +32,9 @@ class SerializationWriterProxyFactory(SerializationWriterFactory):
             on_start (Optional[Callable[[Parsable, SerializationWriter], None]]): the callback to
             invoke when the serialization of a model object starts
         """
+        if not concrete:
+            raise ValueError("concrete SerializationWriterFactory cannot be None.")
+
         self._concrete = concrete
         self._on_before = on_before
         self._on_after = on_after
@@ -54,9 +57,9 @@ class SerializationWriterProxyFactory(SerializationWriterFactory):
             SerializationWriter: A new SerializationWriter instance for the given content type.
         """
         writer = self._concrete.get_serialization_writer(content_type)
-        original_before = writer.get_on_before_object_serialization()
-        original_after = writer.get_on_after_object_serialization()
-        original_start = writer.get_on_start_object_serialization()
+        original_before = writer.on_before_object_serialization
+        original_after = writer.on_after_object_serialization
+        original_start = writer.on_start_object_serialization
 
         def before_callback(value):
             if self._on_before:
@@ -64,7 +67,7 @@ class SerializationWriterProxyFactory(SerializationWriterFactory):
             if original_before:
                 original_before(value)
 
-        writer.set_on_before_object_serialization(before_callback)
+        writer.on_before_object_serialization = before_callback
 
         def after_callback(value):
             if self._on_after:
@@ -72,7 +75,7 @@ class SerializationWriterProxyFactory(SerializationWriterFactory):
             if original_after:
                 original_after(value)
 
-        writer.set_on_after_object_serialization(after_callback)
+        writer.on_after_object_serialization = after_callback
 
         def start_callback(value1, value2):
             if self._on_start:
@@ -80,6 +83,6 @@ class SerializationWriterProxyFactory(SerializationWriterFactory):
             if original_start:
                 original_start(value1, value2)
 
-        writer.set_on_start_object_serialization(start_callback)
+        writer.on_start_object_serialization = start_callback
 
         return writer

--- a/kiota_abstractions/serialization/serialization_writer_proxy_factory.py
+++ b/kiota_abstractions/serialization/serialization_writer_proxy_factory.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.
+# Licensed under the MIT License.
+# See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
 from typing import Callable, Optional
 
 from .parsable import Parsable

--- a/kiota_abstractions/store/backed_model.py
+++ b/kiota_abstractions/store/backed_model.py
@@ -19,15 +19,12 @@ class BackedModel:
     backing_store: BackingStore
 
     def __setattr__(self, prop, val):
-        if not prop == "backing_store":
-            self.__backing_store.set(prop, val)
-            super().__setattr__(prop, self.__backing_store.get(prop))
-        super().__setattr__(prop, val)
+        if prop == "backing_store":
+            super().__setattr__(prop, val)
+        else:
+            self.backing_store.set(prop, val)
 
-    @property
-    def __backing_store(self):
-        return self.backing_store
-
-    @__backing_store.setter
-    def __backing_store(self, value):
-        self.backing_store = value
+    def __getattribute__(self, prop):
+        if prop == "backing_store":
+            return super().__getattribute__(prop)
+        return self.backing_store.get(prop)

--- a/kiota_abstractions/store/backed_model.py
+++ b/kiota_abstractions/store/backed_model.py
@@ -4,9 +4,7 @@
 # See License in the project root for license information.
 # ------------------------------------------------------------------------------
 
-from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Optional
 
 from .backing_store import BackingStore
 
@@ -27,4 +25,12 @@ class BackedModel:
     def __getattribute__(self, prop):
         if prop == "backing_store":
             return super().__getattribute__(prop)
-        return self.backing_store.get(prop)
+        if self.backing_store.get(prop) is not None:
+            return self.backing_store.get(prop)
+        try:
+            attr = super().__getattribute__(prop)
+            if callable(attr): # methods such as serialize and get_field_deserializers
+                return attr
+            return None
+        except AttributeError:
+            return None

--- a/kiota_abstractions/store/backed_model.py
+++ b/kiota_abstractions/store/backed_model.py
@@ -29,7 +29,7 @@ class BackedModel:
             return self.backing_store.get(prop)
         try:
             attr = super().__getattribute__(prop)
-            if callable(attr): # methods such as serialize and get_field_deserializers
+            if callable(attr):  # methods such as serialize and get_field_deserializers
                 return attr
             return None
         except AttributeError:

--- a/kiota_abstractions/store/backed_model.py
+++ b/kiota_abstractions/store/backed_model.py
@@ -1,17 +1,33 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.
+# Licensed under the MIT License.
+# See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Optional
 
 from .backing_store import BackingStore
 
 
-class BackedModel(ABC):
+@dataclass
+class BackedModel:
     """Defines the contracts for a model that is backed by a store.
     """
+    # Stores model information.
+    backing_store: BackingStore
 
-    @abstractmethod
-    def get_backing_store(self) -> BackingStore:
-        """Gets the store that is backing the model
+    def __setattr__(self, prop, val):
+        if not prop == "backing_store":
+            self.__backing_store.set(prop, val)
+            super().__setattr__(prop, self.__backing_store.get(prop))
+        super().__setattr__(prop, val)
 
-        Returns:
-            BackingStore: The store backing the model
-        """
-        pass
+    @property
+    def __backing_store(self):
+        return self.backing_store
+
+    @__backing_store.setter
+    def __backing_store(self, value):
+        self.backing_store = value

--- a/kiota_abstractions/store/backing_store.py
+++ b/kiota_abstractions/store/backing_store.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.
+# Licensed under the MIT License.
+# See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Generic, List, Optional, Tuple, TypeVar
 
@@ -7,8 +13,7 @@ T = TypeVar("T")
 class BackingStore(ABC, Generic[T]):
     """Stores model information in a different location than the object properties.
     Implementations can provide dirty tracking capabilities, caching capabilities
-    or integration with 3rd party stores
-    """
+    or integration with 3rd party stores"""
 
     @abstractmethod
     def get(self, key: str) -> Optional[T]:
@@ -54,7 +59,9 @@ class BackingStore(ABC, Generic[T]):
 
     @abstractmethod
     def subscribe(
-        self, callback: Callable[[str, Any, Any], None], subscription_id: Optional[str]
+        self,
+        callback: Callable[[str, Any, Any], None],
+        subscription_id: Optional[str] = None
     ) -> str:
         """Creates a subscription to any data change happening.
 
@@ -83,8 +90,9 @@ class BackingStore(ABC, Generic[T]):
         """Clears the data stored in the backing store. Doesn't trigger any subscription."""
         pass
 
+    @property
     @abstractmethod
-    def get_is_initialization_completed(self) -> bool:
+    def is_initialization_completed(self) -> bool:
         """Whether the initialization of the object and/or the initial deserialization has been
         completed to track whether objects have changed.
 
@@ -93,15 +101,20 @@ class BackingStore(ABC, Generic[T]):
         """
         pass
 
+    @is_initialization_completed.setter
     @abstractmethod
-    def set_is_initialization_completed(self, completed) -> None:
-        """Sets whether the initialization of the object and/or the initial deserialization has been
-        completed to track whether objects have changed.
+    def is_initialization_completed(self, completed: bool) -> None:
+        """Sets the initialization completed state of the object.
+
+        Args:
+            completed (bool): Whether the initialization of the object and/or the initial
+            deserialization has been completed to track whether objects have changed.
         """
         pass
 
+    @property
     @abstractmethod
-    def get_return_only_changed_values(self) -> bool:
+    def return_only_changed_values(self) -> bool:
         """Whether to return only values that have changed since the initialization of the object
         when calling the Get and Enumerate methods.
 
@@ -110,12 +123,14 @@ class BackingStore(ABC, Generic[T]):
         """
         pass
 
+    @return_only_changed_values.setter
     @abstractmethod
-    def set_return_only_changed_values(self, changed) -> None:
+    def return_only_changed_values(self, changed: bool) -> None:
         """Sets whether to return only values that have changed since the initialization of the
         object when calling the Get and Enumerate methods.
 
-        Returns:
-            bool:
+        Args:
+            changed (bool): Whether to return only values that have changed since the
+            initialization of the object when calling the Get and Enumerate methods.
         """
         pass

--- a/kiota_abstractions/store/backing_store_factory.py
+++ b/kiota_abstractions/store/backing_store_factory.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.
+# Licensed under the MIT License.
+# See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
 from abc import ABC, abstractmethod
 
 from .backing_store import BackingStore

--- a/kiota_abstractions/store/backing_store_factory_singleton.py
+++ b/kiota_abstractions/store/backing_store_factory_singleton.py
@@ -1,9 +1,13 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.
+# Licensed under the MIT License.
+# See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
 from typing_extensions import Self
 
 from kiota_abstractions.store.backing_store_factory import BackingStoreFactory
-from kiota_abstractions.store.in_memory_backing_store_factory import (
-    InMemoryBackingStoreFactory,
-)
+from kiota_abstractions.store.in_memory_backing_store_factory import InMemoryBackingStoreFactory
 
 
 class BackingStoreFactorySingleton:

--- a/kiota_abstractions/store/backing_store_parse_node_factory.py
+++ b/kiota_abstractions/store/backing_store_parse_node_factory.py
@@ -26,6 +26,6 @@ class BackingStoreParseNodeFactory(ParseNodeProxyFactory):
 
         def on_after_deserialization(x):
             if isinstance(x, BackedModel) and x.backing_store:
-                x.backing_store.set_is_initialization_completed(True)
+                x.backing_store.is_initialization_completed = True
 
         super().__init__(concrete, on_before_deserialization, on_after_deserialization)

--- a/kiota_abstractions/store/backing_store_parse_node_factory.py
+++ b/kiota_abstractions/store/backing_store_parse_node_factory.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.
+# Licensed under the MIT License.
+# See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
 from typing import Callable
 
 from ..serialization import Parsable, ParseNodeFactory, ParseNodeProxyFactory

--- a/kiota_abstractions/store/backing_store_parse_node_factory.py
+++ b/kiota_abstractions/store/backing_store_parse_node_factory.py
@@ -21,17 +21,11 @@ class BackingStoreParseNodeFactory(ParseNodeProxyFactory):
         """
 
         def func1(x):
-            if isinstance(x, BackedModel):
-                backed_model = x
-                backing_store = backed_model.get_backing_store()
-                if backing_store:
-                    backing_store.set_is_initialization_completed(False)
+            if isinstance(x, BackedModel) and x.backing_store:
+                x.backing_store.is_initialization_completed = False
 
         def func2(x):
-            if isinstance(x, BackedModel):
-                backed_model = x
-                backing_store = backed_model.get_backing_store()
-                if backing_store:
-                    backing_store.set_is_initialization_completed(True)
+            if isinstance(x, BackedModel) and x.backing_store:
+                x.backing_store.set_is_initialization_completed(True)
 
         super().__init__(concrete, func1, func2)

--- a/kiota_abstractions/store/backing_store_parse_node_factory.py
+++ b/kiota_abstractions/store/backing_store_parse_node_factory.py
@@ -20,12 +20,12 @@ class BackingStoreParseNodeFactory(ParseNodeProxyFactory):
         implementation ParseNodeFactory.
         """
 
-        def func1(x):
+        def on_before_deserialization(x):
             if isinstance(x, BackedModel) and x.backing_store:
                 x.backing_store.is_initialization_completed = False
 
-        def func2(x):
+        def on_after_deserialization(x):
             if isinstance(x, BackedModel) and x.backing_store:
                 x.backing_store.set_is_initialization_completed(True)
 
-        super().__init__(concrete, func1, func2)
+        super().__init__(concrete, on_before_deserialization, on_after_deserialization)

--- a/kiota_abstractions/store/backing_store_serialization_writer_proxy_factory.py
+++ b/kiota_abstractions/store/backing_store_serialization_writer_proxy_factory.py
@@ -22,28 +22,28 @@ class BackingStoreSerializationWriterProxyFactory(SerializationWriterProxyFactor
             SerializationWriterFactory to wrap.
         """
 
-        def func1(x):
+        def on_before(x):
             if isinstance(x, BackedModel):
                 backed_model = x
-                backing_store = backed_model.get_backing_store()
+                backing_store = backed_model.backing_store
                 if backing_store:
-                    backing_store.set_return_only_changed_values(True)
+                    backing_store.return_only_changed_values = True
 
-        def func2(x):
+        def on_after(x):
             if isinstance(x, BackedModel):
                 backed_model = x
-                backing_store = backed_model.get_backing_store()
+                backing_store = backed_model.backing_store
                 if backing_store:
-                    backing_store.set_return_only_changed_values(False)
-                    backing_store.set_is_initialization_completed(True)
+                    backing_store.return_only_changed_values = False
+                    backing_store.is_initialization_completed = True
 
-        def func3(x, y):
+        def on_start(x, y):
             if isinstance(x, BackedModel):
                 backed_model = x
-                backing_store = backed_model.get_backing_store()
+                backing_store = backed_model.backing_store
                 if backing_store:
                     keys = backing_store.enumerate_keys_for_values_changed_to_null()
                     for key in keys:
                         y.write_null_value(key)
 
-        super().__init__(concrete, func1, func2, func3)
+        super().__init__(concrete, on_before, on_after, on_start)

--- a/kiota_abstractions/store/backing_store_serialization_writer_proxy_factory.py
+++ b/kiota_abstractions/store/backing_store_serialization_writer_proxy_factory.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.
+# Licensed under the MIT License.
+# See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
 from ..serialization import SerializationWriterFactory, SerializationWriterProxyFactory
 from .backed_model import BackedModel
 

--- a/kiota_abstractions/store/in_memory_backing_store.py
+++ b/kiota_abstractions/store/in_memory_backing_store.py
@@ -10,8 +10,6 @@ from uuid import uuid4
 from .backed_model import BackedModel
 from .backing_store import BackingStore
 
-# SubscriptionCallback = TypeVar('SubscriptionCallback', Callable[[str, Any, Any], None])
-
 T = TypeVar("T")
 
 
@@ -69,8 +67,8 @@ class InMemoryBackingStore(BackingStore, Generic[T]):
             result_value = result[1]
             if isinstance(result_value, tuple):
                 result_value = result_value[0]
-            if not self.return_only_changed_values or (
-                self.return_only_changed_values and self.__store[key][0]
+            if self.return_only_changed_values is False or (
+                self.return_only_changed_values is True and self.__store[key][0]
             ):
                 return result_value
             return None

--- a/kiota_abstractions/store/in_memory_backing_store.py
+++ b/kiota_abstractions/store/in_memory_backing_store.py
@@ -1,11 +1,16 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.
+# Licensed under the MIT License.
+# See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
 from typing import Any, Callable, Dict, Generic, List, Optional, Tuple, TypeVar
 from uuid import uuid4
 
+from .backed_model import BackedModel
 from .backing_store import BackingStore
 
-StoreEntryWrapper = Tuple[bool, Any]
-SubscriptionCallback = Callable[[str, Any, Any], None]
-StoreEntry = Tuple[str, Any]
+# SubscriptionCallback = TypeVar('SubscriptionCallback', Callable[[str, Any, Any], None])
 
 T = TypeVar("T")
 
@@ -13,11 +18,38 @@ T = TypeVar("T")
 class InMemoryBackingStore(BackingStore, Generic[T]):
     """In-memory implementation of the backing store. Allows for dirty tracking of changes."""
 
-    __subscriptions: Dict[str, SubscriptionCallback] = {}
-    __store: Dict[str, Tuple[bool, Any]] = {}
-    __initialization_completed: bool = True
+    def __init__(self) -> None:
 
-    return_only_changed_values: bool = False
+        self.__subscriptions: Dict[str, Callable[[str, Any, Any], None]] = {}
+        self.__store: Dict[str, Tuple[bool, Any]] = {}
+        self.__initialization_completed: bool = True
+        self.__return_only_changed_values: bool = False
+
+    @property
+    def is_initialization_completed(self) -> bool:
+        """Flag to show the initialization status of the store."""
+        return self.__initialization_completed
+
+    @is_initialization_completed.setter
+    def is_initialization_completed(self, value: bool) -> None:
+        self.__initialization_completed = value
+        for key, val in self.__store.items():
+            if isinstance(val[1], BackedModel):
+                # forward the initialization status to nested BackedModel instances
+                val[1].backing_store.is_initialization_completed = value
+            self._ensure_collection_size_is_consistent(key, val[1])
+            self.__store[key] = (not value, val[1])
+
+    @property
+    def return_only_changed_values(self) -> bool:
+        """Determines whether the backing store should only return changed values when queried."""
+        return self.__return_only_changed_values
+
+    @return_only_changed_values.setter
+    def return_only_changed_values(self, value: bool) -> None:
+        """Sets the flag to determines whether the backing store should only return changed values
+        when queried."""
+        self.__return_only_changed_values = value
 
     def get(self, key: str) -> Optional[T]:
         """Gets the specified object with the given key from the store.
@@ -28,12 +60,20 @@ class InMemoryBackingStore(BackingStore, Generic[T]):
         Returns:
             Optional[T]: An instance of T
         """
-        wrapper = self.__store.get(key)
+        if not key:
+            raise ValueError("Key cannot be empty or None")
 
-        if wrapper and (
-            self.return_only_changed_values and wrapper[0] or not self.return_only_changed_values
-        ):
-            return wrapper[1]
+        result = self.__store.get(key)
+        if result:
+            self._ensure_collection_size_is_consistent(key, result[1])
+            result_value = result[1]
+            if isinstance(result_value, tuple):
+                result_value = result_value[0]
+            if not self.return_only_changed_values or (
+                self.return_only_changed_values and self.__store[key][0]
+            ):
+                return result_value
+            return None
         return None
 
     def set(self, key: str, value: T) -> None:
@@ -43,27 +83,52 @@ class InMemoryBackingStore(BackingStore, Generic[T]):
             key (str): The key to use
             value (T): The object value to store
         """
-        old_value_wrapper = self.__store.get(key)
-        old_value = None
-        if old_value_wrapper:
-            old_value = old_value_wrapper[1]
-        self.__store[key] = (self.get_is_initialization_completed(), value)
-        for val in self.__subscriptions.values():
-            val(key, old_value, value)
+        if not key:
+            raise ValueError("Key cannot be empty or None")
 
-    def enumerate_(self) -> List[StoreEntry]:
+        old_value = self.__store.get(key)
+        value_to_add = (self.is_initialization_completed, value)
+        if isinstance(value, list):
+            value_to_add = (self.is_initialization_completed, (value, len(value)))  # type: ignore
+
+        if key not in self.__store:
+            if isinstance(value, BackedModel) and value.backing_store:
+                # if its the first time adding a BackedModel property to the store, subscribe
+                # to its BackingStore and use the events to flag the property is "dirty"
+                value.backing_store.subscribe(
+                    lambda prop_key, old_val, new_val: self.set(key, value)
+                )
+            if isinstance(value, list):
+                # if its a collection, subscribe to the collection's item BackingStores and use
+                # the events to flag the collection property is "dirty"
+                for item in value:
+                    if isinstance(item, BackedModel) and item.backing_store:
+                        item.backing_store.subscribe(
+                            lambda prop_key, old_val, new_val: self.set(key, value)
+                        )
+
+        self.__store[key] = value_to_add
+        for sub in self.__subscriptions.values():
+            sub(key, old_value, value_to_add)
+
+    def enumerate_(self) -> List[Tuple[str, Any]]:
         """Enumerate the values in the store based on the ReturnOnlyChangedValues configuration
         value
 
         Returns:
-            List[StoreEntry]: A collection of changed values or the whole store based on the
+            List[Tuple[str, Any]]: A collection of changed values or the whole store based on the
             ReturnOnlyChangedValues configuration value.
         """
-        filterable_array = list(self.__store.items())
+
+        # refresh the state of collection properties if they've changed in size.
         if self.return_only_changed_values:
-            filtered = [elem for elem in filterable_array if elem[0] is True]
-            return filtered
-        return filterable_array
+            for key, val in list(self.__store.items()):
+                self._ensure_collection_size_is_consistent(key, val[1])
+
+        keyval_pairs = list(self.__store.items())
+        if self.return_only_changed_values:
+            return [(key, val[1]) for key, val in keyval_pairs if val[0] is True]
+        return [(key, val[1]) for key, val in keyval_pairs]
 
     def enumerate_keys_for_values_changed_to_null(self) -> List[str]:
         """Enumerate the values in the store that have changed to None
@@ -71,16 +136,14 @@ class InMemoryBackingStore(BackingStore, Generic[T]):
         Returns:
             List[str]: A collection of strings containing keys changed to None
         """
-        keys: List[str] = []
-        for key, val in self.__store.items():
-            if val[0] and not val[1]:
-                keys.append(key)
-        return keys
+        return [key for key, val in self.__store.items() if val[0] and val[1] is None]
 
     def subscribe(
-        self, callback: Callable[[str, Any, Any], None], subscription_id: Optional[str]
+        self,
+        callback: Callable[[str, Any, Any], None],
+        subscription_id: Optional[str] = None
     ) -> str:
-        """dds a callback to subscribe to events in the store with the given subscription id
+        """Adds a callback to subscribe to events in the store with the given subscription id
 
         Args:
             callback (Callable[[str, Any, Any], None]): The callback to add
@@ -89,8 +152,12 @@ class InMemoryBackingStore(BackingStore, Generic[T]):
         Returns:
             str: The id of the subscription
         """
+        if not callable(callback):
+            raise ValueError("Callback must be a callable function")
+
         if not subscription_id:
             subscription_id = str(uuid4())
+
         self.__subscriptions[subscription_id] = callback
         return subscription_id
 
@@ -106,21 +173,30 @@ class InMemoryBackingStore(BackingStore, Generic[T]):
         """Clears the store"""
         self.__store.clear()
 
-    def get_is_initialization_completed(self) -> bool:
-        """Flag to show the initialization status of the store."""
-        return self.__initialization_completed
+    def _ensure_collection_size_is_consistent(self, key: str, entry: Any) -> None:
+        """Checks if entry of type collection has changed in size.
+        If so, dirty tracks the change by calling set()
 
-    def set_is_initialization_completed(self, value: bool) -> None:
-        self.__initialization_completed = value
-        for key, val in self.__store.items():
-            self.__store[key] = (not value, val[1])
-
-    def get_return_only_changed_values(self) -> bool:
-        """Determines whether the backing store should only return changed values when queried."""
-        return self.return_only_changed_values
-
-    def set_return_only_changed_values(self, value: bool) -> None:
-        """Sets the flag to determines whether the backing store should only return changed values
-        when queried.
+        Args:
+            key (str): _description_
+            entry(StoreEntry): _description_
         """
-        self.return_only_changed_values = value
+        # Check if the entry is a tuple of a collection annotated with the size
+        if isinstance(entry, tuple):
+            backed_models = [item for item in entry[0] if isinstance(item, BackedModel)]
+            for backed_model in backed_models:
+                values = backed_model.backing_store.enumerate_()
+                for value in values:
+                    # Call get() on nested properties so that this method may be called recursively
+                    # to ensure collections are consistent
+                    backed_model.backing_store.get(value[0])
+
+            if len(entry[0]) != entry[1]:  # if the size has changed since last update
+                self.set(key, entry[0])  # dirty track the change
+
+        elif isinstance(entry, BackedModel):
+            values = entry.backing_store.enumerate_()
+            for value in values:
+                # Call get() on nested properties so that this method may be called recursively
+                # to ensure collections are consistent
+                entry.backing_store.get(value[0])

--- a/kiota_abstractions/store/in_memory_backing_store_factory.py
+++ b/kiota_abstractions/store/in_memory_backing_store_factory.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.
+# Licensed under the MIT License.
+# See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
 from .backing_store import BackingStore
 from .backing_store_factory import BackingStoreFactory
 from .in_memory_backing_store import InMemoryBackingStore

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
-from typing import Callable, List, Any, Tuple
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Callable, List, Any, Tuple, Dict, Optional
 import pytest
 
 from kiota_abstractions.authentication.access_token_provider import AccessTokenProvider
@@ -6,11 +8,8 @@ from kiota_abstractions.authentication.allowed_hosts_validator import (
     AllowedHostsValidator,
 )
 from kiota_abstractions.request_information import RequestInformation
-from kiota_abstractions.store import (
-    BackingStore,
-    InMemoryBackingStore,
-    BackingStoreFactory,
-)
+from kiota_abstractions.serialization import AdditionalDataHolder, Parsable, ParseNode, SerializationWriter
+from kiota_abstractions.store import BackedModel, BackingStore, BackingStoreFactorySingleton
 
 
 class MockAccessTokenProvider(AccessTokenProvider):
@@ -23,6 +22,72 @@ class MockAccessTokenProvider(AccessTokenProvider):
     def get_allowed_hosts_validator(self) -> AllowedHostsValidator:
         return AllowedHostsValidator(["example.com"])
 
+@dataclass
+class MockEntity(Parsable, AdditionalDataHolder, BackedModel):
+    # Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
+    additional_data: Dict[str, Any] = field(default_factory=dict)
+    # Stores model information.
+    backing_store : BackingStore = field(default_factory=BackingStoreFactorySingleton(backing_store_factory=None).backing_store_factory.create_backing_store)
+    # The id property
+    id: Optional[str] = None
+    # The OdataType property
+    odata_type: str = "#microsoft.graph.mockEntity"
+    # The telephone numbers for the user. NOTE: Although this is a string collection, only one number can be set for this property. Read-only for users synced from on-premises directory. Returned by default. Supports $filter (eq, not, ge, le, startsWith).
+    business_phones: Optional[List[str]] = None
+    # The user or contact that is this user&apos;s manager. Read-only. (HTTP Methods: GET, PUT, DELETE.). Supports $expand.
+    manager: Optional[MockEntity] = None
+    # The user or contact that is this user& works with.
+    colleagues: Optional[List[MockEntity]] = None
+    
+    @staticmethod
+    def create_from_discriminator_value(parse_node: Optional[ParseNode] = None):
+        """
+        Creates a new instance of the appropriate class based on discriminator value
+        Args:
+            parse_node: The parse node to use to read the discriminator value and create the object
+        Returns: AccessAction
+        """
+        if not parse_node:
+            raise TypeError("parse_node cannot be null.")
+        return MockEntity()
+    
+    def get_field_deserializers(self,) -> Dict[str, Callable[[ParseNode], None]]:
+        """
+        The deserialization information for the current model
+        Returns: Dict[str, Callable[[ParseNode], None]]
+        """
+        fields: Dict[str, Callable[[Any], None]] = {
+            "@odata.type": lambda n : setattr(self, 'odata_type', n.get_str_value()),
+            "id": lambda n : setattr(self, 'id', n.get_str_value()),
+            "businessPhones": lambda n : setattr(self, 'business_phones', n.get_collection_of_primitive_values(str)),
+            "manager": lambda n : setattr(self, 'manager', n.get_object_value(MockEntity)),
+            "colleagues": lambda n : setattr(self, 'colleagues', n.get_collection_of_object_values(MockEntity)),
+        }
+        return fields
+    
+    def serialize(self,writer: SerializationWriter) -> None:
+        """
+        Serializes information the current object
+        Args:
+            writer: Serialization writer to use to serialize this model
+        """
+        if not writer:
+            raise TypeError("writer cannot be null.")
+        writer.write_str_value("@odata.type", self.odata_type)
+        writer.write_additional_data_value(self.additional_data)
+        writer.write_str_value("id", self.id)
+        writer.write_collection_of_primitive_values("businessPhones", self.business_phones)
+        writer.write_object_value("manager", self.manager)
+        writer.write_collection_of_object_values("colleagues", self.colleagues)
+    
+@pytest.fixture
+def mock_user():
+    user = MockEntity()
+    user.id = "84b3f7bf-6afb-46b2-9c6d-660c9b8c8ea0"
+    user.additional_data = {"extensionData": None}
+    user.business_phones = ["+1 732 555 0102"]
+    user.backing_store.is_initialization_completed = True
+    return user
 
 @pytest.fixture
 def mock_request_information():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.
+# Licensed under the MIT License.
+# See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
 from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Callable, List, Any, Tuple, Dict, Optional

--- a/tests/store/test_backed_model.py
+++ b/tests/store/test_backed_model.py
@@ -1,0 +1,21 @@
+import pytest
+
+def test_backed_model_return_only_changed_values_false(mock_user):
+    # Getters retrieve all values from backing store
+    assert mock_user.id == "84b3f7bf-6afb-46b2-9c6d-660c9b8c8ea0"
+    assert mock_user.odata_type == "#microsoft.graph.mockEntity"
+    assert mock_user.additional_data == {"extensionData": None}
+    assert mock_user.business_phones == ["+1 732 555 0102"]
+
+def test_backed_model_return_only_changed_values_true(mock_user):
+    # Set the backing store to only return changed values
+    mock_user.backing_store.return_only_changed_values = True
+    # No changes have been made to the backing store, getters should return None
+    assert mock_user.id is None
+    assert mock_user.odata_type is None
+    assert mock_user.business_phones is None
+    # change a property value
+    mock_user.business_phones = ["+1 234 567 8901"]
+    # returns the changed value
+    assert mock_user.business_phones == ["+1 234 567 8901"]
+    

--- a/tests/store/test_backed_model.py
+++ b/tests/store/test_backed_model.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.
+# Licensed under the MIT License.
+# See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
 import pytest
 
 def test_backed_model_return_only_changed_values_false(mock_user):

--- a/tests/store/test_backing_store_factory_singleton.py
+++ b/tests/store/test_backing_store_factory_singleton.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.
+# Licensed under the MIT License.
+# See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
 from typing import Any, Callable, TypeVar, Generic, List, Tuple
 import pytest
 

--- a/tests/store/test_in_memory_backing_store.py
+++ b/tests/store/test_in_memory_backing_store.py
@@ -1,0 +1,195 @@
+import pytest
+
+from kiota_abstractions.store import InMemoryBackingStore
+
+from tests.conftest import MockEntity
+
+def test_prevents_adding_empty_keys():
+    backing_store = InMemoryBackingStore()
+    with pytest.raises(ValueError):
+        backing_store.set("", "Samwel")
+        
+def test_sets_and_gets_value_from_backing_store():
+    backing_store = InMemoryBackingStore()
+    assert not backing_store.enumerate_()
+    backing_store.set("name", "Samwel")
+    assert backing_store.enumerate_() == [("name", "Samwel")]
+    
+def test_prevents_duplicates_in_store():
+    backing_store = InMemoryBackingStore()
+    assert not backing_store.enumerate_()
+    backing_store.set("name", "Samwel")
+    backing_store.set("name", "Samwel 2")
+    assert backing_store.enumerate_() == [("name", "Samwel 2")]
+    
+def test_enumerates_values_changed_to_none_in_store():
+    backing_store = InMemoryBackingStore()
+    assert not backing_store.enumerate_()
+    backing_store.set("name", "Samwel")
+    backing_store.set("email", "samwel@example.com")
+    backing_store.set("phone", None) # remove phone
+    assert backing_store.enumerate_keys_for_values_changed_to_null()
+    assert backing_store.enumerate_keys_for_values_changed_to_null() == ["phone"]
+    assert len(backing_store.enumerate_()) == 3
+    
+def test_backing_store_embedded_in_model(mock_user):
+    mock_user.business_phones = ["+1 234 567 891"]
+    mock_user.backing_store.return_only_changed_values = True
+    changed_values = dict(mock_user.backing_store.enumerate_())
+    assert len(changed_values) == 1
+    assert "business_phones" in changed_values
+    
+
+    
+def tests_backing_store_embedded_in_model_with_additonal_data_values(mock_user):
+    mock_user.business_phones = ["+1 234 567 891"]
+    mock_user.additional_data = {"anotherExtension": None}
+    mock_user.backing_store.return_only_changed_values = True
+    changed_values = dict(mock_user.backing_store.enumerate_())
+    assert len(changed_values) == 2
+    assert "business_phones" in changed_values
+    assert "additional_data" in changed_values
+    
+def test_backing_store_embedded_in_model_with_collection_property_replaced_with_new_collection(mock_user):
+    mock_user.business_phones = ["+1 234 567 891"]
+    mock_user.backing_store.return_only_changed_values = True
+    changed_values = mock_user.backing_store.enumerate_()
+    assert len(changed_values) == 1
+    assert  changed_values[0][0] == "business_phones"
+    business_phones = mock_user.backing_store.get("business_phones")
+    assert business_phones == ["+1 234 567 891"]
+    
+def test_backing_store_embedded_in_model_with_collection_property_replaced_with_none(mock_user):
+    mock_user.business_phones = None
+    mock_user.backing_store.return_only_changed_values = True
+    changed_values = mock_user.backing_store.enumerate_()
+    assert len(changed_values) == 1
+    assert  changed_values[0][0] == "business_phones"
+    assert changed_values[0][1] == None
+    values_changed_to_null = mock_user.backing_store.enumerate_keys_for_values_changed_to_null()
+    assert values_changed_to_null == ["business_phones"]
+    
+def test_backing_store_embedded_in_model_with_collection_property_modified_by_append(mock_user):
+    mock_user.business_phones.append("+1 234 567 891")
+    mock_user.backing_store.return_only_changed_values = True
+    changed_values = mock_user.backing_store.enumerate_()
+    assert len(changed_values) == 1
+    assert  changed_values[0][0] == "business_phones"
+    assert len(mock_user.backing_store.get("business_phones")) == 2 # 2 items in collection as the property was modified by add
+    
+def test_backing_store_embedded_in_model_by_setting_nested_backed_model(mock_user):
+    mock_user.manager = MockEntity(id="2f8c9b8c-8ea0-46b2-9c6d-660c9b7bf6af")
+    mock_user.backing_store.return_only_changed_values = True
+    changed_values = mock_user.backing_store.enumerate_()
+    assert len(changed_values) == 1
+    assert  changed_values[0][0] == "manager"
+    manager = changed_values[0][1]
+    assert manager.id == "2f8c9b8c-8ea0-46b2-9c6d-660c9b7bf6af"
+    
+def test_backing_store_embedded_in_model_by_updating_nested_backed_model():
+    mock_user = MockEntity(
+        id="84c747c1-d2c0-410d-ba50-fc23e0b4abbe",
+        manager=MockEntity(id="2f8c9b8c-8ea0-46b2-9c6d-660c9b7bf6af")
+    )
+    mock_user.backing_store.is_initialization_completed = mock_user.manager.backing_store.is_initialization_completed = True
+    mock_user.manager.business_phones = ["+1 234 567 891"]
+    mock_user.backing_store.return_only_changed_values = True
+    changed_values = mock_user.backing_store.enumerate_()
+    assert len(changed_values) == 1
+    assert  changed_values[0][0] == "manager" # Backingstore should detect manager property changed
+    
+def test_backing_store_embedded_in_model_by_updating_nested_backed_model_returns_changed_nested_properties():
+    mock_user = MockEntity(
+        id="84c747c1-d2c0-410d-ba50-fc23e0b4abbe",
+        manager=MockEntity(id="2f8c9b8c-8ea0-46b2-9c6d-660c9b7bf6af")
+    )
+    mock_user.backing_store.is_initialization_completed = mock_user.manager.backing_store.is_initialization_completed = True
+    mock_user.manager.business_phones = ["+1 234 567 891"]
+    mock_user.backing_store.return_only_changed_values = True
+    mock_user.manager.backing_store.return_only_changed_values = True
+    changed_values = mock_user.backing_store.enumerate_()
+    assert len(changed_values) == 1
+    assert  changed_values[0][0] == "manager" # Backingstore should detect manager property changed
+    nested_changed_values = mock_user.manager.backing_store.enumerate_()
+    assert len(nested_changed_values) == 1
+    assert nested_changed_values[0][0] == "business_phones"
+    
+def test_backing_store_embedded_in_model_by_updating_nested_backed_model_collection_property():
+    mock_user = MockEntity(
+        id="84c747c1-d2c0-410d-ba50-fc23e0b4abbe",
+        colleagues=[MockEntity(id="2f8c9b8c-8ea0-46b2-9c6d-660c9b7bf6af")]
+    )
+    mock_user.backing_store.is_initialization_completed = mock_user.colleagues[0].backing_store.is_initialization_completed = True
+    mock_user.colleagues[0].business_phones = ["+1 234 567 891"]
+    mock_user.backing_store.return_only_changed_values = True
+    changed_values = mock_user.backing_store.enumerate_()
+    assert len(changed_values) == 1
+    assert  changed_values[0][0] == "colleagues" # Backingstore should detect manager property changed
+    colleagues = mock_user.backing_store.get("colleagues")
+    assert colleagues[0].id == "2f8c9b8c-8ea0-46b2-9c6d-660c9b7bf6af"
+    
+def test_backing_store_embedded_in_model_by_updating_nested_backed_model_collection_property_returns_changed_nested_properties():
+    mock_user = MockEntity(
+        id="84c747c1-d2c0-410d-ba50-fc23e0b4abbe",
+        colleagues=[MockEntity(id="2f8c9b8c-8ea0-46b2-9c6d-660c9b7bf6af")]
+    )
+    mock_user.backing_store.is_initialization_completed = mock_user.colleagues[0].backing_store.is_initialization_completed = True
+    mock_user.colleagues[0].business_phones = ["+1 234 567 891"]
+    mock_user.backing_store.return_only_changed_values = True
+    mock_user.colleagues[0].backing_store.return_only_changed_values = True
+    changed_values = mock_user.backing_store.enumerate_()
+    assert len(changed_values) == 1
+    assert  changed_values[0][0] == "colleagues" # Backingstore should detect manager property changed
+    nested_changed_values = mock_user.colleagues[0].backing_store.enumerate_()
+    assert len(nested_changed_values) == 1
+    assert nested_changed_values[0][0] == "business_phones"
+    
+def test_backing_store_embedded_in_model_by_updating_nested_backed_model_collection_property_with_extra_value_returns_changed_nested_properties():
+    mock_user = MockEntity(
+        id="84c747c1-d2c0-410d-ba50-fc23e0b4abbe",
+        colleagues=[MockEntity(
+            id="2f8c9b8c-8ea0-46b2-9c6d-660c9b7bf6af",
+            business_phones=["+1 234 567 891"]
+            )]
+    )
+    mock_user.backing_store.is_initialization_completed = mock_user.colleagues[0].backing_store.is_initialization_completed = True
+    mock_user.colleagues[0].business_phones.append("+9 876 543 219")
+    mock_user.backing_store.return_only_changed_values = True
+    mock_user.colleagues[0].backing_store.return_only_changed_values = True
+    changed_values = mock_user.backing_store.enumerate_()
+    assert len(changed_values) == 1
+    assert  changed_values[0][0] == "colleagues" # Backingstore should detect manager property changed
+    nested_changed_values = mock_user.colleagues[0].backing_store.enumerate_()
+    assert len(nested_changed_values) == 1
+    assert nested_changed_values[0][0] == "business_phones"
+    assert nested_changed_values[0][1] == (["+1 234 567 891", "+9 876 543 219"], 2)
+    
+def test_backing_store_embedded_in_model_by_updating_nested_backed_model_collection_property_with_extra_backed_model_returns_changed_nested_properties():
+    mock_user = MockEntity(
+        id="84c747c1-d2c0-410d-ba50-fc23e0b4abbe",
+        colleagues=[MockEntity(
+            id="2f8c9b8c-8ea0-46b2-9c6d-660c9b7bf6af",
+            business_phones=["+1 234 567 891"]
+            )]
+    )
+    mock_user.backing_store.is_initialization_completed = mock_user.colleagues[0].backing_store.is_initialization_completed = True
+    mock_user.colleagues.append(MockEntity(id="2fe22fe5-1132-42cf-90f9-1dc17e325a74"))
+    mock_user.backing_store.return_only_changed_values = True
+    mock_user.colleagues[0].backing_store.return_only_changed_values = True
+    changed_values = mock_user.backing_store.enumerate_()
+    assert len(changed_values) == 1
+    assert  changed_values[0][0] == "colleagues" # Backingstore should detect manager property changed
+    colleagues = changed_values[0][1]
+    assert len(colleagues) == 2
+    assert colleagues[0][0].id == "2f8c9b8c-8ea0-46b2-9c6d-660c9b7bf6af"
+    assert colleagues[0][1].id == "2fe22fe5-1132-42cf-90f9-1dc17e325a74"
+    nested_changed_values = mock_user.colleagues[0].backing_store.enumerate_()
+    assert len(nested_changed_values) == 0
+        
+        
+    
+    
+    
+    
+
+        

--- a/tests/store/test_in_memory_backing_store.py
+++ b/tests/store/test_in_memory_backing_store.py
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.  All Rights Reserved.
+# Licensed under the MIT License.
+# See License in the project root for license information.
+# ------------------------------------------------------------------------------
+
 import pytest
 
 from kiota_abstractions.store import InMemoryBackingStore

--- a/tests/store/test_in_memory_backing_store.py
+++ b/tests/store/test_in_memory_backing_store.py
@@ -10,6 +10,8 @@ from kiota_abstractions.store import InMemoryBackingStore
 
 from tests.conftest import MockEntity
 
+BUSINESS_PHONES_KEY = "business_phones"
+BUSINESS_PHONES_1 = "+1 234 567 891"
 
 def test_prevents_adding_empty_keys():
     backing_store = InMemoryBackingStore()
@@ -62,47 +64,47 @@ def test_enumerates_values_changed_to_none_in_store():
     assert len(backing_store.enumerate_()) == 3
     
 def test_backing_store_embedded_in_model(mock_user):
-    mock_user.business_phones = ["+1 234 567 891"]
+    mock_user.business_phones = [BUSINESS_PHONES_1]
     mock_user.backing_store.return_only_changed_values = True
     changed_values = dict(mock_user.backing_store.enumerate_())
     assert len(changed_values) == 1
-    assert "business_phones" in changed_values
+    assert BUSINESS_PHONES_KEY in changed_values
     
 def tests_backing_store_embedded_in_model_with_additonal_data_values(mock_user):
-    mock_user.business_phones = ["+1 234 567 891"]
+    mock_user.business_phones = [BUSINESS_PHONES_1]
     mock_user.additional_data = {"anotherExtension": None}
     mock_user.backing_store.return_only_changed_values = True
     changed_values = dict(mock_user.backing_store.enumerate_())
     assert len(changed_values) == 2
-    assert "business_phones" in changed_values
+    assert BUSINESS_PHONES_KEY in changed_values
     assert "additional_data" in changed_values
     
 def test_backing_store_embedded_in_model_with_collection_property_replaced_with_new_collection(mock_user):
-    mock_user.business_phones = ["+1 234 567 891"]
+    mock_user.business_phones = [BUSINESS_PHONES_1]
     mock_user.backing_store.return_only_changed_values = True
     changed_values = mock_user.backing_store.enumerate_()
     assert len(changed_values) == 1
-    assert  changed_values[0][0] == "business_phones"
-    business_phones = mock_user.backing_store.get("business_phones")
-    assert business_phones == ["+1 234 567 891"]
+    assert  changed_values[0][0] == BUSINESS_PHONES_KEY
+    business_phones = mock_user.backing_store.get(BUSINESS_PHONES_KEY)
+    assert business_phones == [BUSINESS_PHONES_1]
     
 def test_backing_store_embedded_in_model_with_collection_property_replaced_with_none(mock_user):
     mock_user.business_phones = None
     mock_user.backing_store.return_only_changed_values = True
     changed_values = mock_user.backing_store.enumerate_()
     assert len(changed_values) == 1
-    assert  changed_values[0][0] == "business_phones"
+    assert  changed_values[0][0] == BUSINESS_PHONES_KEY
     assert changed_values[0][1] == None
     values_changed_to_null = mock_user.backing_store.enumerate_keys_for_values_changed_to_null()
-    assert values_changed_to_null == ["business_phones"]
+    assert values_changed_to_null == [BUSINESS_PHONES_KEY]
     
 def test_backing_store_embedded_in_model_with_collection_property_modified_by_append(mock_user):
-    mock_user.business_phones.append("+1 234 567 891")
+    mock_user.business_phones.append(BUSINESS_PHONES_1)
     mock_user.backing_store.return_only_changed_values = True
     changed_values = mock_user.backing_store.enumerate_()
     assert len(changed_values) == 1
-    assert  changed_values[0][0] == "business_phones"
-    assert len(mock_user.backing_store.get("business_phones")) == 2 # 2 items in collection as the property was modified by add
+    assert  changed_values[0][0] == BUSINESS_PHONES_KEY
+    assert len(mock_user.backing_store.get(BUSINESS_PHONES_KEY)) == 2 # 2 items in collection as the property was modified by add
     
 def test_backing_store_embedded_in_model_by_setting_nested_backed_model(mock_user):
     mock_user.manager = MockEntity(id="2f8c9b8c-8ea0-46b2-9c6d-660c9b7bf6af")
@@ -119,7 +121,7 @@ def test_backing_store_embedded_in_model_by_updating_nested_backed_model():
         manager=MockEntity(id="2f8c9b8c-8ea0-46b2-9c6d-660c9b7bf6af")
     )
     mock_user.backing_store.is_initialization_completed = mock_user.manager.backing_store.is_initialization_completed = True
-    mock_user.manager.business_phones = ["+1 234 567 891"]
+    mock_user.manager.business_phones = [BUSINESS_PHONES_1]
     mock_user.backing_store.return_only_changed_values = True
     changed_values = mock_user.backing_store.enumerate_()
     assert len(changed_values) == 1
@@ -131,7 +133,7 @@ def test_backing_store_embedded_in_model_by_updating_nested_backed_model_returns
         manager=MockEntity(id="2f8c9b8c-8ea0-46b2-9c6d-660c9b7bf6af")
     )
     mock_user.backing_store.is_initialization_completed = mock_user.manager.backing_store.is_initialization_completed = True
-    mock_user.manager.business_phones = ["+1 234 567 891"]
+    mock_user.manager.business_phones = [BUSINESS_PHONES_1]
     mock_user.backing_store.return_only_changed_values = True
     mock_user.manager.backing_store.return_only_changed_values = True
     changed_values = mock_user.backing_store.enumerate_()
@@ -139,7 +141,7 @@ def test_backing_store_embedded_in_model_by_updating_nested_backed_model_returns
     assert  changed_values[0][0] == "manager" # Backingstore should detect manager property changed
     nested_changed_values = mock_user.manager.backing_store.enumerate_()
     assert len(nested_changed_values) == 1
-    assert nested_changed_values[0][0] == "business_phones"
+    assert nested_changed_values[0][0] == BUSINESS_PHONES_KEY
     
 def test_backing_store_embedded_in_model_by_updating_nested_backed_model_collection_property():
     mock_user = MockEntity(
@@ -147,7 +149,7 @@ def test_backing_store_embedded_in_model_by_updating_nested_backed_model_collect
         colleagues=[MockEntity(id="2f8c9b8c-8ea0-46b2-9c6d-660c9b7bf6af")]
     )
     mock_user.backing_store.is_initialization_completed = mock_user.colleagues[0].backing_store.is_initialization_completed = True
-    mock_user.colleagues[0].business_phones = ["+1 234 567 891"]
+    mock_user.colleagues[0].business_phones = [BUSINESS_PHONES_1]
     mock_user.backing_store.return_only_changed_values = True
     changed_values = mock_user.backing_store.enumerate_()
     assert len(changed_values) == 1
@@ -161,7 +163,7 @@ def test_backing_store_embedded_in_model_by_updating_nested_backed_model_collect
         colleagues=[MockEntity(id="2f8c9b8c-8ea0-46b2-9c6d-660c9b7bf6af")]
     )
     mock_user.backing_store.is_initialization_completed = mock_user.colleagues[0].backing_store.is_initialization_completed = True
-    mock_user.colleagues[0].business_phones = ["+1 234 567 891"]
+    mock_user.colleagues[0].business_phones = [BUSINESS_PHONES_1]
     mock_user.backing_store.return_only_changed_values = True
     mock_user.colleagues[0].backing_store.return_only_changed_values = True
     changed_values = mock_user.backing_store.enumerate_()
@@ -169,14 +171,14 @@ def test_backing_store_embedded_in_model_by_updating_nested_backed_model_collect
     assert  changed_values[0][0] == "colleagues" # Backingstore should detect manager property changed
     nested_changed_values = dict(mock_user.colleagues[0].backing_store.enumerate_())
     assert len(nested_changed_values) == 6
-    assert "business_phones" in nested_changed_values
+    assert BUSINESS_PHONES_KEY in nested_changed_values
     
 def test_backing_store_embedded_in_model_by_updating_nested_backed_model_collection_property_with_extra_value_returns_changed_nested_properties():
     mock_user = MockEntity(
         id="84c747c1-d2c0-410d-ba50-fc23e0b4abbe",
         colleagues=[MockEntity(
             id="2f8c9b8c-8ea0-46b2-9c6d-660c9b7bf6af",
-            business_phones=["+1 234 567 891"]
+            business_phones=[BUSINESS_PHONES_1]
             )]
     )
     mock_user.backing_store.is_initialization_completed = mock_user.colleagues[0].backing_store.is_initialization_completed = True
@@ -189,8 +191,8 @@ def test_backing_store_embedded_in_model_by_updating_nested_backed_model_collect
     nested_changed_values = dict(mock_user.colleagues[0].backing_store.enumerate_())
     assert len(nested_changed_values) == 6
     assert "id" in nested_changed_values
-    assert "business_phones" in nested_changed_values
-    assert nested_changed_values["business_phones"] == (["+1 234 567 891", "+9 876 543 219"], 2)
+    assert BUSINESS_PHONES_KEY in nested_changed_values
+    assert nested_changed_values[BUSINESS_PHONES_KEY] == ([BUSINESS_PHONES_1, "+9 876 543 219"], 2)
     
 def test_backing_store_embedded_in_model_by_updating_nested_backed_model_collection_property_with_extra_backed_model_returns_changed_nested_properties():
     mock_user = MockEntity(
@@ -198,7 +200,7 @@ def test_backing_store_embedded_in_model_by_updating_nested_backed_model_collect
         colleagues=[
             MockEntity(
                 id="2f8c9b8c-8ea0-46b2-9c6d-660c9b7bf6af",
-                business_phones=["+1 234 567 891"])
+                business_phones=[BUSINESS_PHONES_1])
         ]
     )
     mock_user.backing_store.is_initialization_completed = mock_user.colleagues[0].backing_store.is_initialization_completed = True
@@ -215,8 +217,8 @@ def test_backing_store_embedded_in_model_by_updating_nested_backed_model_collect
     nested_changed_values = dict(mock_user.colleagues[0].backing_store.enumerate_())
     assert len(nested_changed_values) == 6
     assert "id" in nested_changed_values
-    assert "business_phones" in nested_changed_values
-    assert nested_changed_values["business_phones"] == (["+1 234 567 891"], 1)
+    assert BUSINESS_PHONES_KEY in nested_changed_values
+    assert nested_changed_values[BUSINESS_PHONES_KEY] == ([BUSINESS_PHONES_1], 1)
     
         
         


### PR DESCRIPTION
Enables backing store for Python.

Part of https://github.com/microsoft/kiota/issues/2858

- [x] Add a backing store interface in the abstractions
- [x] Add a backed model interface in the abstractions
- [x] Add an in memory backing store implementation in the abstractions
- [x] Add a backing store factory interface in the abstractions
- [x] Implement the factory for the in memory backing store
- [x] Add a singleton for the backing store factory in the abstractions
- [x] Implement factories for proxy
- [x] [implement those factories for the backing store