### PR TITLE
Bugfix/backed model initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.7.1] - 2023-08-09
 
 ### Added
-- Added an abstract translator method that should convert a `RequestInformation` object into the native client HTTP request object.
-- Enable backing store for Python.
 
 ### Changed
 - Set the default value for the `is_initialization_completed` parameter in the `InMemoryBackingStore` class to be `False` and use the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2023-08-09
+
+### Added
+- Added an abstract translator method that should convert a `RequestInformation` object into the native client HTTP request object.
+- Enable backing store for Python.
+
+### Changed
+- Set the default value for the `is_initialization_completed` parameter in the `InMemoryBackingStore` class to be `False` and use the
+`__post_init__` method of backed model to set it to `True`.
+- Changed the string representation of the `APIError` class to be more descriptive.
+
 ## [0.7.0] - 2023-07-27
 
 ### Added

--- a/kiota_abstractions/_version.py
+++ b/kiota_abstractions/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = "0.7.0"
+VERSION: str = "0.7.1"

--- a/kiota_abstractions/api_error.py
+++ b/kiota_abstractions/api_error.py
@@ -1,5 +1,4 @@
-from dataclasses import asdict, dataclass
-from json import dumps
+from dataclasses import dataclass
 from typing import Dict, Optional
 
 
@@ -12,4 +11,5 @@ class APIError(Exception):
     response_headers: Optional[Dict[str, str]] = None
 
     def __str__(self) -> str:
-        return dumps(asdict(self), default=str)
+        return f"""APIError {self.response_status_code}: {self.message} {self.__getattribute__(
+                'error')}"""

--- a/kiota_abstractions/store/backed_model.py
+++ b/kiota_abstractions/store/backed_model.py
@@ -16,6 +16,9 @@ class BackedModel:
     # Stores model information.
     backing_store: BackingStore
 
+    def __post_init__(self):
+        self.backing_store.is_initialization_completed = True
+
     def __setattr__(self, prop, val):
         if prop == "backing_store":
             super().__setattr__(prop, val)

--- a/kiota_abstractions/store/in_memory_backing_store.py
+++ b/kiota_abstractions/store/in_memory_backing_store.py
@@ -20,7 +20,7 @@ class InMemoryBackingStore(BackingStore, Generic[T]):
 
         self.__subscriptions: Dict[str, Callable[[str, Any, Any], None]] = {}
         self.__store: Dict[str, Tuple[bool, Any]] = {}
-        self.__initialization_completed: bool = True
+        self.__initialization_completed: bool = False
         self.__return_only_changed_values: bool = False
 
     @property

--- a/tests/store/test_in_memory_backing_store.py
+++ b/tests/store/test_in_memory_backing_store.py
@@ -55,6 +55,7 @@ def test_return_only_changed_values():
     
 def test_enumerates_values_changed_to_none_in_store():
     backing_store = InMemoryBackingStore()
+    backing_store.is_initialization_completed = True
     assert not backing_store.enumerate_()
     backing_store.set("name", "Samwel")
     backing_store.set("email", "samwel@example.com")


### PR DESCRIPTION
##  SUMMARY

1. Fixes a bug in Python backed models where `is_initialization_completed` property of backing store is set as `True` before default values are set, which results in the values being marked as changed. We set `is_initialization_completed` property to False by default and use the `__post_init__` method of the model classes to set the property to `True`.
2. Updates the `str` method of `APIError` to provide more detailed error messages.