### PR TITLE
Use `getattr` inbuilt with a default empty string

### DIFF
--- a/kiota_abstractions/api_error.py
+++ b/kiota_abstractions/api_error.py
@@ -11,5 +11,4 @@ class APIError(Exception):
     response_headers: Optional[Dict[str, str]] = None
 
     def __str__(self) -> str:
-        return f"""APIError {self.response_status_code}: {self.message} {self.__getattribute__(
-                'error')}"""
+        return f"""APIError {self.response_status_code}: {self.message} {getattr('error', '')}"""


### PR DESCRIPTION
Closes #133 

Try getting the 'error' attribute and return an empty string if it is not found.