### PR TITLE
Bugfix/error string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.3] - 2023-09-13
+
+### Added
+
+### Changed
+- Fix error representation when APIError class has no error attribute.
+
 ## [0.8.2] - 2023-09-13
 
 ### Added

--- a/kiota_abstractions/_version.py
+++ b/kiota_abstractions/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = "0.8.2"
+VERSION: str = "0.8.3"

--- a/kiota_abstractions/api_error.py
+++ b/kiota_abstractions/api_error.py
@@ -14,19 +14,13 @@ class APIError(Exception):
         error = getattr(self, "error", None)
         if error:
             return f"""
-            APIError 
-            Code: {self.response_status_code}
-            message: {self.message}
-            error: {getattr(self, 'error', None)}
-            """
+        APIError
+        Code: {self.response_status_code}
+        message: {self.message}
+        error: {error}
+        """
         return f"""
-        APIError 
+        APIError
         Code: {self.response_status_code}
         message: {self.message}
         """
-    
-    
-    
-
-err = APIError("test", 404, {"test": "test"})
-print(err)

--- a/kiota_abstractions/api_error.py
+++ b/kiota_abstractions/api_error.py
@@ -11,4 +11,22 @@ class APIError(Exception):
     response_headers: Optional[Dict[str, str]] = None
 
     def __str__(self) -> str:
-        return f"""APIError {self.response_status_code}: {self.message} {getattr('error', '')}"""
+        error = getattr(self, "error", None)
+        if error:
+            return f"""
+            APIError 
+            Code: {self.response_status_code}
+            message: {self.message}
+            error: {getattr(self, 'error', None)}
+            """
+        return f"""
+        APIError 
+        Code: {self.response_status_code}
+        message: {self.message}
+        """
+    
+    
+    
+
+err = APIError("test", 404, {"test": "test"})
+print(err)


### PR DESCRIPTION
Displays useful error representation depending on whether the `APIError` class contains a custom `error` attribute as is the case with many APIs e.g ODataError for graph.