### PR TITLE
Bugfix/backed model initialization with arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.4] - 2023-09-14
+
+### Added
+
+### Changed
+- Fix error when instantiating BackedModel using positional and keyword arguments
+
 ## [0.8.3] - 2023-09-13
 
 ### Added

--- a/kiota_abstractions/_version.py
+++ b/kiota_abstractions/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = "0.8.3"
+VERSION: str = "0.8.4"

--- a/kiota_abstractions/store/backed_model.py
+++ b/kiota_abstractions/store/backed_model.py
@@ -4,7 +4,7 @@
 # See License in the project root for license information.
 # ------------------------------------------------------------------------------
 
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 
 from .backing_store import BackingStore
 
@@ -18,22 +18,15 @@ class BackedModel:
 
     def __post_init__(self):
         self.backing_store.is_initialization_completed = True
+        for field in fields(self):
+            if field.name != "backing_store":
+                field_val = getattr(self, field.name)
+                if field_val is not field.default:
+                    self.backing_store.set(field.name, field_val)
 
     def __setattr__(self, prop, val):
         if prop == "backing_store":
             super().__setattr__(prop, val)
         else:
             self.backing_store.set(prop, val)
-
-    def __getattribute__(self, prop):
-        if prop == "backing_store":
-            return super().__getattribute__(prop)
-        if self.backing_store.get(prop) is not None:
-            return self.backing_store.get(prop)
-        try:
-            attr = super().__getattribute__(prop)
-            if callable(attr):  # methods such as serialize and get_field_deserializers
-                return attr
-            return None
-        except AttributeError:
-            return None
+            super().__setattr__(prop, self.backing_store.get(prop))

--- a/tests/store/test_backed_model.py
+++ b/tests/store/test_backed_model.py
@@ -16,12 +16,11 @@ def test_backed_model_return_only_changed_values_false(mock_user):
 def test_backed_model_return_only_changed_values_true(mock_user):
     # Set the backing store to only return changed values
     mock_user.backing_store.return_only_changed_values = True
-    # No changes have been made to the backing store, getters should return None
-    assert mock_user.id is None
-    assert mock_user.odata_type is None
-    assert mock_user.business_phones is None
+    # No changes have been made to the backing store
+    # enumerate should return an empty list
+    assert mock_user.backing_store.enumerate_() == []
     # change a property value
     mock_user.business_phones = ["+1 234 567 8901"]
     # returns the changed value
-    assert mock_user.business_phones == ["+1 234 567 8901"]
+    assert mock_user.backing_store.enumerate_() == [('business_phones', (["+1 234 567 8901"], 1))]
     


### PR DESCRIPTION
Fixes a bug where initializing a backed mode with arguments doesn't mark the values as changed.

Example:
```py
request_body = MovePostRequestBody(
    destination_id = "inbox",
)

response = user \
    .mail_folders.by_mail_folder_id(staging_folder_to_fetch_from_parent) \
    .messages.by_message_id(email_id) \
    .move.post(body = request_body)
```
`response`: The value of the parameter 'DestinationId' is empty

 This is because `backing_store.is_initialization_completed` is still `False` during object initialization which results in no request body during post/put/patch requests. 

Solution: After initialization, Iterate over the object and mark the attributes initialized using arguments as changed.