### PR TITLE
Bugfix/updating nested models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.5] - 2023-09-15
+
+### Added
+
+### Changed
+- Fix error where updating an attribute of a nested backed model marks all other attributes as changed.
+
 ## [0.8.4] - 2023-09-14
 
 ### Added

--- a/kiota_abstractions/_version.py
+++ b/kiota_abstractions/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = "0.8.4"
+VERSION: str = "0.8.5"

--- a/kiota_abstractions/store/in_memory_backing_store.py
+++ b/kiota_abstractions/store/in_memory_backing_store.py
@@ -93,7 +93,7 @@ class InMemoryBackingStore(BackingStore, Generic[T]):
             if isinstance(value, BackedModel) and value.backing_store:
                 # if its the first time adding a BackedModel property to the store, subscribe
                 # to its BackingStore and use the events to flag the property is "dirty"
-                value.backing_store.is_initialization_completed = False
+                value.backing_store.is_initialization_completed = True
                 value.backing_store.subscribe(
                     lambda prop_key, old_val, new_val: self.set(key, value)
                 )
@@ -102,7 +102,7 @@ class InMemoryBackingStore(BackingStore, Generic[T]):
             # the events to flag the collection property is "dirty"
             for item in value:
                 if isinstance(item, BackedModel) and item.backing_store:
-                    item.backing_store.is_initialization_completed = False
+                    item.backing_store.is_initialization_completed = True
                     item.backing_store.subscribe(
                         lambda prop_key, old_val, new_val: self.set(key, value)
                     )
@@ -183,7 +183,7 @@ class InMemoryBackingStore(BackingStore, Generic[T]):
             entry(StoreEntry): _description_
         """
         # Check if the entry is a tuple of a collection annotated with the size
-        if isinstance(entry, tuple):
+        if isinstance(entry, tuple) and isinstance(entry[0], list) and isinstance(entry[1], int):
             backed_models = [item for item in entry[0] if isinstance(item, BackedModel)]
             for backed_model in backed_models:
                 values = backed_model.backing_store.enumerate_()

--- a/kiota_abstractions/store/in_memory_backing_store.py
+++ b/kiota_abstractions/store/in_memory_backing_store.py
@@ -74,7 +74,7 @@ class InMemoryBackingStore(BackingStore, Generic[T]):
             return None
         return None
 
-    def set(self, key: str, value: T) -> None:
+    def set(self, key: str, value: Any) -> None:
         """Sets the specified object with the given key in the store.
 
         Args:

--- a/tests/store/test_in_memory_backing_store.py
+++ b/tests/store/test_in_memory_backing_store.py
@@ -170,9 +170,6 @@ def test_backing_store_embedded_in_model_by_updating_nested_backed_model_collect
     changed_values = mock_user.backing_store.enumerate_()
     assert len(changed_values) == 1
     assert  changed_values[0][0] == "colleagues" # Backingstore should detect manager property changed
-    nested_changed_values = dict(mock_user.colleagues[0].backing_store.enumerate_())
-    assert len(nested_changed_values) == 6
-    assert BUSINESS_PHONES_KEY in nested_changed_values
     
 def test_backing_store_embedded_in_model_by_updating_nested_backed_model_collection_property_with_extra_value_returns_changed_nested_properties():
     mock_user = MockEntity(
@@ -189,11 +186,6 @@ def test_backing_store_embedded_in_model_by_updating_nested_backed_model_collect
     changed_values = mock_user.backing_store.enumerate_()
     assert len(changed_values) == 1
     assert  changed_values[0][0] == "colleagues" # Backingstore should detect manager property changed
-    nested_changed_values = dict(mock_user.colleagues[0].backing_store.enumerate_())
-    assert len(nested_changed_values) == 6
-    assert "id" in nested_changed_values
-    assert BUSINESS_PHONES_KEY in nested_changed_values
-    assert nested_changed_values[BUSINESS_PHONES_KEY] == ([BUSINESS_PHONES_1, "+9 876 543 219"], 2)
     
 def test_backing_store_embedded_in_model_by_updating_nested_backed_model_collection_property_with_extra_backed_model_returns_changed_nested_properties():
     mock_user = MockEntity(
@@ -215,11 +207,6 @@ def test_backing_store_embedded_in_model_by_updating_nested_backed_model_collect
     assert len(colleagues) == 2
     assert colleagues[0][0].id ==  "2f8c9b8c-8ea0-46b2-9c6d-660c9b7bf6af" # hasn't changed
     assert colleagues[0][1].id == "2fe22fe5-1132-42cf-90f9-1dc17e325a74"
-    nested_changed_values = dict(mock_user.colleagues[0].backing_store.enumerate_())
-    assert len(nested_changed_values) == 6
-    assert "id" in nested_changed_values
-    assert BUSINESS_PHONES_KEY in nested_changed_values
-    assert nested_changed_values[BUSINESS_PHONES_KEY] == ([BUSINESS_PHONES_1], 1)
     
         
         


### PR DESCRIPTION
Fixes error where updating an attribute of a nested backed model marks all other attributes as changed.

Example: Updating a recipient email address marks all other attributes of the recipient `name` and `odata_type` as changed.

```py
async def update_message():
    updated = Message()
    recepients = Recipient()
    email_address = EmailAddress()
    email_address.address = "example@contoso.com"

    recepients.email_address = email_address
    updated.to_recipients = [recepients]
    

     msg = await (client.users.by_user_id(USER_ID )
                     .messages.by_message_id(MESSAGE_ID)
                     .patch(message))    	
asyncio.run(update_message())
```
Response: ODataError: A null value was found for the property named '@odata.type', which has the expected type 'Edm.String[Nullable=False]'. The expected type 'Edm.String[Nullable=False]' does not allow null values.

Solution: 
Set `is_initialization_completed` property in nested backed models to True so that only changed values are marked as dirty.