### PR TITLE
Bugfix/serialize parsable multipart body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2024-03-05
+
+### Added
+
+### Changed
+
+- Fixed a bug with serialization of parsable multipart body due to unsubscriptable argument type.
+
 ## [1.3.0] - 2024-02-28
 
 ### Added

--- a/kiota_abstractions/_version.py
+++ b/kiota_abstractions/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = "1.3.0"
+VERSION: str = "1.3.1"

--- a/kiota_abstractions/multipart_body.py
+++ b/kiota_abstractions/multipart_body.py
@@ -108,7 +108,7 @@ class MultipartBody(Parsable, Generic[T]):
             self._add_new_line(writer)
 
             if isinstance(part_value[1], Parsable):
-                self._write_parsable(writer, part_value[1])
+                self._write_parsable(writer, part_value)
             elif isinstance(part_value[1], str):
                 writer.write_str_value("", part_value[1])
             elif isinstance(part_value[1], bytes):


### PR DESCRIPTION
## Overview

Fixes a bug where serialization of Parsable multipart body would raise a `Parsable object not subscriptable` error due to unsbscriptable argument type passed.