### PR TITLE
Fix deprication warning being reported on import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2024-03-25
+
+### Added
+
+### Changed
+
+- Moved DepricationWarning to __post_init__ of BaseRequestConfiguration. [microsoft/kiota#250](https://github.com/microsoft/kiota-abstractions-python/pull/250)
+
+
 ## [1.3.1] - 2024-03-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Moved DepricationWarning to __post_init__ of BaseRequestConfiguration. [microsoft/kiota#250](https://github.com/microsoft/kiota-abstractions-python/pull/250)
+- Moved DeprecationWarning to __post_init__ of BaseRequestConfiguration. [microsoft/kiota#250](https://github.com/microsoft/kiota-abstractions-python/pull/250)
 
 
 ## [1.3.1] - 2024-03-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.4.1] - 2024-03-25
+## [1.3.2] - 2024-03-25
 
 ### Added
 

--- a/kiota_abstractions/_version.py
+++ b/kiota_abstractions/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = "1.3.1"
+VERSION: str = "1.4.1"

--- a/kiota_abstractions/_version.py
+++ b/kiota_abstractions/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = "1.4.1"
+VERSION: str = "1.3.2"

--- a/kiota_abstractions/base_request_configuration.py
+++ b/kiota_abstractions/base_request_configuration.py
@@ -28,7 +28,8 @@ class RequestConfiguration(Generic[QueryParameters]):
 
 @dataclass
 class BaseRequestConfiguration(RequestConfiguration):
-    warn(
-        "BaseRequestConfiguration is deprecated. Use RequestConfiguration class instead.",
-        DeprecationWarning
-    )
+    def __post_init__(self):
+        warn(
+            "BaseRequestConfiguration is deprecated. Use RequestConfiguration class instead.",
+            DeprecationWarning
+        )

--- a/kiota_abstractions/base_request_configuration.py
+++ b/kiota_abstractions/base_request_configuration.py
@@ -28,6 +28,7 @@ class RequestConfiguration(Generic[QueryParameters]):
 
 @dataclass
 class BaseRequestConfiguration(RequestConfiguration):
+
     def __post_init__(self):
         warn(
             "BaseRequestConfiguration is deprecated. Use RequestConfiguration class instead.",

--- a/tests/test_base_request_configuration.py
+++ b/tests/test_base_request_configuration.py
@@ -1,0 +1,13 @@
+import pytest
+
+from kiota_abstractions.base_request_configuration import BaseRequestConfiguration
+
+
+def test_base_request_configuration_deprecation_warning():
+    with pytest.warns(DeprecationWarning, match="BaseRequestConfiguration is deprecated. Use RequestConfiguration class instead."):
+        BaseRequestConfiguration()
+
+
+def test_import_base_request_configuration_no_warning():
+    from kiota_abstractions.base_request_configuration import BaseRequestConfiguration, RequestConfiguration
+    assert len(pytest.warns()) == 0


### PR DESCRIPTION
## Overview

`DeprecationWarning` was being reported on import.

```
ImportError while loading conftest '/app/tests/conftest.py'.
tests/conftest.py:11: in <module>
    from src.core.fastapi import get_application, get_router
src/core/fastapi.py:9: in <module>
    from msgraph import GraphServiceClient
/usr/local/lib/python3.12/site-packages/msgraph/__init__.py:5: in <module>
    from .graph_request_adapter import GraphRequestAdapter
/usr/local/lib/python3.12/site-packages/msgraph/graph_request_adapter.py:3: in <module>
    from kiota_abstractions.authentication import AuthenticationProvider
/usr/local/lib/python3.12/site-packages/kiota_abstractions/authentication/__init__.py:3: in <module>
    from .anonymous_authentication_provider import AnonymousAuthenticationProvider
/usr/local/lib/python3.12/site-packages/kiota_abstractions/authentication/anonymous_authentication_provider.py:9: in <module>
    from ..request_information import RequestInformation
/usr/local/lib/python3.12/site-packages/kiota_abstractions/request_information.py:20: in <module>
    from .base_request_configuration import RequestConfiguration
/usr/local/lib/python3.12/site-packages/kiota_abstractions/base_request_configuration.py:30: in <module>
    class BaseRequestConfiguration(RequestConfiguration):
/usr/local/lib/python3.12/site-packages/kiota_abstractions/base_request_configuration.py:31: in BaseRequestConfiguration
    warn(
E   DeprecationWarning: BaseRequestConfiguration is deprecated. Use RequestConfiguration class instead.
```

## Related Issue

Fixes # (issue)

### Demo

Simplest reproduction

```
python -Wd -c "from kiota_abstractions.base_request_configuration import RequestConfiguration"
/Users/jacobzyworonek/Repo/kiota-abstractions-python/kiota_abstractions/base_request_configuration.py:31: DeprecationWarning: BaseRequestConfiguration is deprecated. Use RequestConfiguration class instead.
  warn(
```

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output