### PR TITLE
Adds path/query parameter sanization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [1.3.3] - 2024-05-21
+
+### Added
+
+### Changed
+
+- Adds support for guid and date parameters in the url. [#245](https://github.com/microsoft/kiota-abstractions-python/issues/245)
+
 ## [1.3.2] - 2024-03-25
 
 ### Added

--- a/kiota_abstractions/_version.py
+++ b/kiota_abstractions/_version.py
@@ -1,1 +1,1 @@
-VERSION: str = "1.3.2"
+VERSION: str = "1.3.3"

--- a/kiota_abstractions/request_information.py
+++ b/kiota_abstractions/request_information.py
@@ -303,6 +303,12 @@ class RequestInformation:
             return ','.join([x.value for x in value])
         if isinstance(value, UUID):
             return str(value)
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, date):
+            return str(value)
+        if isinstance(value, time):
+            return str(value)
         return value
 
     def _decode_uri_string(self, uri: Optional[str]) -> str:

--- a/kiota_abstractions/request_information.py
+++ b/kiota_abstractions/request_information.py
@@ -109,10 +109,10 @@ class RequestInformation:
 
         data: Dict[str, Any] = {}
         for key, val in self.query_parameters.items():
-            val = self._replace_enum_values_with_string_representation(val)
+            val = self._get_sanitized_value(val)
             data[key] = val
         for key, val in self.path_parameters.items():
-            val = self._replace_enum_values_with_string_representation(val)
+            val = self._get_sanitized_value(val)
             data[key] = val
 
         result = StdUriTemplate.expand(self.url_template, data)
@@ -291,7 +291,7 @@ class RequestInformation:
             self.headers.try_add(self.CONTENT_TYPE_HEADER, content_type)
         self.content = writer.get_serialized_content()
 
-    def _replace_enum_values_with_string_representation(self, value: Any) -> Any:
+    def _get_sanitized_value(self, value: Any) -> Any:
         """Replaces enum values with their string representation.
 
         Args:
@@ -301,6 +301,8 @@ class RequestInformation:
             return value.value
         if isinstance(value, list) and all(isinstance(x, Enum) for x in value):
             return ','.join([x.value for x in value])
+        if isinstance(value, UUID):
+            return str(value)
         return value
 
     def _decode_uri_string(self, uri: Optional[str]) -> str:

--- a/kiota_abstractions/request_information.py
+++ b/kiota_abstractions/request_information.py
@@ -302,14 +302,10 @@ class RequestInformation:
             sanitized_value = value.value
         elif isinstance(value, list) and all(isinstance(x, Enum) for x in value):
             sanitized_value = ','.join([x.value for x in value])
-        elif isinstance(value, UUID):
+        elif any([isinstance(value, UUID), isinstance(value, date), isinstance(value, time)]:)
             sanitized_value = str(value)
         elif isinstance(value, datetime):
             sanitized_value = value
-        elif isinstance(value, date):
-            sanitized_value = str(value)
-        elif isinstance(value, time):
-            sanitized_value = str(value)
         return sanitized_value
 
     def _decode_uri_string(self, uri: Optional[str]) -> str:

--- a/kiota_abstractions/request_information.py
+++ b/kiota_abstractions/request_information.py
@@ -297,19 +297,20 @@ class RequestInformation:
         Args:
             value (Any): The value to replace.
         """
+        sanitized_value = value
         if isinstance(value, Enum):
-            return value.value
-        if isinstance(value, list) and all(isinstance(x, Enum) for x in value):
-            return ','.join([x.value for x in value])
-        if isinstance(value, UUID):
-            return str(value)
-        if isinstance(value, datetime):
-            return value
-        if isinstance(value, date):
-            return str(value)
-        if isinstance(value, time):
-            return str(value)
-        return value
+            sanitized_value = value.value
+        elif isinstance(value, list) and all(isinstance(x, Enum) for x in value):
+            sanitized_value = ','.join([x.value for x in value])
+        elif isinstance(value, UUID):
+            sanitized_value = str(value)
+        elif isinstance(value, datetime):
+            sanitized_value = value
+        elif isinstance(value, date):
+            sanitized_value = str(value)
+        elif isinstance(value, time):
+            sanitized_value = str(value)
+        return sanitized_value
 
     def _decode_uri_string(self, uri: Optional[str]) -> str:
         """Decodes a URI encoded string."""

--- a/kiota_abstractions/request_information.py
+++ b/kiota_abstractions/request_information.py
@@ -302,10 +302,10 @@ class RequestInformation:
             sanitized_value = value.value
         elif isinstance(value, list) and all(isinstance(x, Enum) for x in value):
             sanitized_value = ','.join([x.value for x in value])
-        elif any([isinstance(value, UUID), isinstance(value, date), isinstance(value, time)]:)
-            sanitized_value = str(value)
         elif isinstance(value, datetime):
             sanitized_value = value
+        elif any([isinstance(value, UUID), isinstance(value, date), isinstance(value, time)]):
+            sanitized_value = str(value)
         return sanitized_value
 
     def _decode_uri_string(self, uri: Optional[str]) -> str:

--- a/tests/test_request_information.py
+++ b/tests/test_request_information.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import uuid
 import pytest
 from dataclasses import dataclass
@@ -189,6 +190,20 @@ def test_sets_uuid_values_in_path_parameters():
     request_info = RequestInformation(Method.GET, "https://example.com/values/{id}")
     request_info.path_parameters["id"] = uuid.UUID("123e4567-e89b-12d3-a456-426614174000")
     assert request_info.url == "https://example.com/values/123e4567-e89b-12d3-a456-426614174000"
+
+def test_sets_bool_values_in_path_parameters():
+    """Tests setting uuid values in path parameters
+    """
+    request_info = RequestInformation(Method.GET, "https://example.com/isTrue/{bool}")
+    request_info.path_parameters["bool"] = True
+    assert request_info.url == "https://example.com/isTrue/true"
+
+def test_sets_datetime_values_in_path_parameters():
+    """Tests setting datetime values in path parameters
+    """
+    request_info = RequestInformation(Method.GET, "https://example.com/daysFrom/{startDate}")
+    request_info.path_parameters["startDate"] = datetime(year=2020, month=8, day=1, hour=0, minute=20, second=0, microsecond=0)
+    assert request_info.url == "https://example.com/daysFrom/2020-08-01T00%3A20%3A00Z"
     
 
     

--- a/tests/test_request_information.py
+++ b/tests/test_request_information.py
@@ -204,6 +204,27 @@ def test_sets_datetime_values_in_path_parameters():
     request_info = RequestInformation(Method.GET, "https://example.com/daysFrom/{startDate}")
     request_info.path_parameters["startDate"] = datetime(year=2020, month=8, day=1, hour=0, minute=20, second=0, microsecond=0)
     assert request_info.url == "https://example.com/daysFrom/2020-08-01T00%3A20%3A00Z"
+
+def test_sets_int_values_in_path_parameters():
+    """Tests setting int values values in path parameters
+    """
+    request_info = RequestInformation(Method.GET, "https://example.com/valuesFromZero/{number}")
+    request_info.path_parameters["number"] = 7
+    assert request_info.url == "https://example.com/valuesFromZero/7"
+
+def test_sets_date_only_values_in_path_parameters():
+    """Tests setting date only values in path parameters
+    """
+    request_info = RequestInformation(Method.GET, "https://example.com/daysFrom/{startDate}")
+    request_info.path_parameters["startDate"] = datetime(year=2020, month=8, day=1, hour=0, minute=20, second=0, microsecond=0).date()
+    assert request_info.url == "https://example.com/daysFrom/2020-08-01"
+
+def test_sets_time_only_values_in_path_parameters():
+    """Tests setting time only values in path parameters
+    """
+    request_info = RequestInformation(Method.GET, "https://example.com/daysFrom/{startDate}")
+    request_info.path_parameters["startDate"] = datetime(year=2020, month=8, day=1, hour=0, minute=20, second=0, microsecond=0).time()
+    assert request_info.url == "https://example.com/daysFrom/00%3A20%3A00"
     
 
     

--- a/tests/test_request_information.py
+++ b/tests/test_request_information.py
@@ -1,3 +1,4 @@
+import uuid
 import pytest
 from dataclasses import dataclass
 from typing import Optional
@@ -181,6 +182,13 @@ def test_sets_enum_values_in_path_parameters():
     request_info = RequestInformation(Method.GET, "https://example.com/{dataset}")
     request_info.path_parameters["dataset"] = [TestEnum.VALUE1, TestEnum.VALUE2]
     assert request_info.url == "https://example.com/value1%2Cvalue2"
+
+def test_sets_uuid_values_in_path_parameters():
+    """Tests setting uuid values in path parameters
+    """
+    request_info = RequestInformation(Method.GET, "https://example.com/values/{id}")
+    request_info.path_parameters["id"] = uuid.UUID("123e4567-e89b-12d3-a456-426614174000")
+    assert request_info.url == "https://example.com/values/123e4567-e89b-12d3-a456-426614174000"
     
 
     


### PR DESCRIPTION
Fixes https://github.com/microsoft/kiota-abstractions-python/issues/245

Sanitizes types passed to the path/query object dictionaries to ensure success of various object types in the parameters. 
Adds tests to validate date,time,datetime,boolean,number and uuid types. 