### PR TITLE
feat: setup release please.

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,9 @@
+{
+  "packages/abstractions": "1.3.4",
+  "packages/authentication/azure": "1.3.4",
+  "packages/http/httpx": "1.3.4",
+  "packages/serialization/json": "1.3.4",
+  "packages/serialization/form": "1.3.4",
+  "packages/serialization/text": "1.3.4",
+  "packages/serialization/multipart": "1.3.4"
+}

--- a/packages/abstractions/CHANGELOG.md
+++ b/packages/abstractions/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [1.3.3] - 2024-05-21
 
 ### Added
@@ -22,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Moved DeprecationWarning to __post_init__ of BaseRequestConfiguration. [microsoft/kiota#250](https://github.com/microsoft/kiota-abstractions-python/pull/250)
 
-
 ## [1.3.1] - 2024-03-05
 
 ### Added
@@ -34,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.3.0] - 2024-02-28
 
 ### Added
+
 - Added multipart body class to support multipart serialization. [microsoft/kiota#3030](https://github.com/microsoft/kiota/issues/3030)
 
 ### Changed
@@ -41,14 +40,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.2.0] - 2024-01-31
 
 ### Added
+
 - Added methods in request information to reduce the amount of code being generated. [microsoft/kiota#3695](https://github.com/microsoft/kiota/issues/3695)
 
 ### Changed
+
 - Fixed an issue where path and query parameters of enum type would not be expanded properly. [microsoft/kiota#3783](https://github.com/microsoft/kiota/issues/3783)
 
 ## [1.1.0] - 2024-01-25
 
 ### Added
+
 - Added an abstract class to mark composed type wrappers and facilitate serialization.
 
 ### Changed
@@ -58,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
 - GA release
 
 ## [0.9.1] - 2023-10-25
@@ -65,19 +68,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
 - Initialize headers in BaseRequestConfiguration to a HeadersCollection instance
 
 ## [0.9.0] - 2023-10-10
 
 ### Added
+
 - Added a content type parameter to the set stream content method in request information.
 
 ### Changed
+
 - Added dedicated HeadersCollection class to manage request headers.
 
 ## [0.8.7] - 2023-10-05
 
 ### Added
+
 - Added a try_add method for request headers
 
 ### Changed
@@ -87,6 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
 - Updated BaseRequestBuilder to set the raw url value if provided.
 
 ## [0.8.5] - 2023-09-15
@@ -94,6 +102,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
 - Fix error where updating an attribute of a nested backed model marks all other attributes as changed.
 
 ## [0.8.4] - 2023-09-14
@@ -101,6 +110,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
 - Fix error when instantiating BackedModel using positional and keyword arguments
 
 ## [0.8.3] - 2023-09-13
@@ -108,6 +118,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
 - Fix error representation when APIError class has no error attribute.
 
 ## [0.8.2] - 2023-09-13
@@ -115,12 +126,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
 - Switched from uritemplate to std-uritemplate for URI templating.
 - Handles exception thrown when APIError class has no error attribute.
 
 ## [0.8.1] - 2023-09-01
 
 ### Added
+
 - Added opentelemetry to project dependencies.
 
 ### Changed
@@ -128,6 +141,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.8.0] - 2023-08-24
 
 ### Added
+
 - Added opentelemetry to support observability.
 - Added an additional parameter to authentication methods to carry contextual information.
 
@@ -138,6 +152,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
 - Set the default value for the `is_initialization_completed` parameter in the `InMemoryBackingStore` class to be `False` and use the
 `__post_init__` method of backed model to set it to `True`.
 - Changed the string representation of the `APIError` class to be more descriptive.
@@ -145,6 +160,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.7.0] - 2023-07-27
 
 ### Added
+
 - Added an abstract translator method that should convert a `RequestInformation` object into the native client HTTP request object.
 - Enable backing store for Python.
 
@@ -153,6 +169,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.6.0] - 2023-06-27
 
 ### Added
+
 - API key authentication provider.
 
 ### Changed
@@ -199,7 +216,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-
 ## [0.4.0] - 2023-02-06
 
 ### Added
@@ -213,4 +229,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
 - Changes the ResponseHandler parameter in RequestAdapter to be a RequestOption

--- a/packages/abstractions/README.md
+++ b/packages/abstractions/README.md
@@ -1,6 +1,6 @@
 # Microsoft Kiota Abstractions Library for Python
+
 [![PyPI version](https://badge.fury.io/py/microsoft-kiota-abstractions.svg)](https://badge.fury.io/py/microsoft-kiota-abstractions)
-[![CI Actions Status](https://github.com/microsoft/kiota-abstractions-python/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/microsoft/kiota-abstractions-python/actions)
 [![Downloads](https://pepy.tech/badge/microsoft-kiota-abstractions)](https://pepy.tech/project/microsoft-kiota-abstractions)
 
 The Microsoft Kiota abstractions library for Python is the python package defining the basic constructs Kiota projects need once an SDK has been generated from an OpenAPI definition.
@@ -21,7 +21,7 @@ pip install microsoft-kiota-abstractions
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
@@ -33,8 +33,8 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ## Trademarks
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft 
-trademarks or logos is subject to and must follow 
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
+trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.

--- a/packages/abstractions/kiota_abstractions/_version.py
+++ b/packages/abstractions/kiota_abstractions/_version.py
@@ -1,1 +1,3 @@
-VERSION: str = "1.3.3"
+import importlib.metadata
+
+VERSION: str = importlib.metadata.version('microsoft-kiota-abstractions')

--- a/packages/abstractions/pyproject.toml
+++ b/packages/abstractions/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "microsoft-kiota-abstractions"
-version = "0.0.4"
+version = "1.3.4"
 description = "Core abstractions for kiota generated libraries in Python"
 authors = ["Microsoft <graphtooling+python@microsoft.com>"]
 license = "MIT"

--- a/packages/authentication/azure/CHANGELOG.md
+++ b/packages/authentication/azure/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.0] - 2023-10-31
+
+### Added
+
+Enabled CAE by default
+
+## [1.0.0] - 2023-10-31
+
+### Added
+
+### Changed
+
+- GA release.
+
+## [0.3.2] - 2023-10-18
+
+### Added
+
+### Changed
+
+- Allow http on localhost.
+
+## [0.3.1] - 2023-09-25
+
+### Added
+
+- Added tracing support using opentelemetry.
+
+### Changed
+
+## [0.3.0] - 2023-08-30
+
+### Added
+
+- Added support for continuous access evaluation.
+
+### Changed

--- a/packages/authentication/azure/README.md
+++ b/packages/authentication/azure/README.md
@@ -1,6 +1,6 @@
 # Microsoft Kiota Authentication Azure Library for Python
+
 [![PyPI version](https://badge.fury.io/py/microsoft-kiota-authentication-azure.svg)](https://badge.fury.io/py/microsoft-kiota-authentication-azure)
-[![CI Actions Status](https://github.com/microsoft/kiota-authentication-azure-python/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/microsoft/kiota-authentication-azure-python/actions)
 [![Downloads](https://pepy.tech/badge/microsoft-kiota-authentication-azure)](https://pepy.tech/project/microsoft-kiota-authentication-azure)
 
 The Microsoft Kiota Authentication Azure Library is an implementation to authenticate HTTP requests using @azure/identity.
@@ -21,7 +21,7 @@ pip install microsoft-kiota-authentication-azure
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
@@ -33,8 +33,8 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ## Trademarks
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft 
-trademarks or logos is subject to and must follow 
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
+trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.

--- a/packages/authentication/azure/kiota_authentication_azure/_version.py
+++ b/packages/authentication/azure/kiota_authentication_azure/_version.py
@@ -1,1 +1,3 @@
-VERSION: str = '1.1.0'
+import importlib.metadata
+
+VERSION: str = importlib.metadata.version('microsoft-kiota-authentication-azure')

--- a/packages/authentication/azure/pyproject.toml
+++ b/packages/authentication/azure/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "microsoft-kiota-authentication-azure"
-version = "0.0.4"
+version = "1.3.4"
 description = "Core abstractions for kiota generated libraries in Python"
 authors = ["Microsoft <graphtooling+python@microsoft.com>"]
 license = "MIT"

--- a/packages/http/httpx/CHANGELOG.md
+++ b/packages/http/httpx/CHANGELOG.md
@@ -1,0 +1,164 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.3.3] - 2024-08-12
+
+### Added
+
+### Changed
+
+- Avoid raising an exception when a relative url is used as redirect location.
+
+## [1.3.2] - 2024-07-09
+
+### Added
+
+### Changed
+
+- Do not use mutable default arguments for HttpxRequestAdapter.[#383](https://github.com/microsoft/kiota-http-python/pull/383)
+
+## [1.3.1] - 2024-02-13
+
+### Added
+
+### Changed
+
+- Bugfix issues with middleware maintaining state across requests.[#281](https://github.com/microsoft/kiota-http-python/issues/281)
+- Fix issue with redirect handler not closing old responses.[#299](https://github.com/microsoft/kiota-http-python/issues/299)
+
+## [1.3.0] - 2024-02-08
+
+### Added
+
+- Added support for `XXX` status code error mapping in RequestAdapter.[#280](https://github.com/microsoft/kiota-http-python/issues/280)
+
+### Changed
+
+## [1.2.1] - 2024-01-22
+
+### Added
+
+### Changed
+
+- Fixed bug with redirect handler maintaing `max_redirect` across requests.[#246](https://github.com/microsoft/kiota-http-python/issues/246)
+
+## [1.2.0] - 2023-11-29
+
+### Added
+
+- Added headers inspection handler to allow clients to inspect request and response headers.
+
+### Changed
+
+## [1.1.0] - 2023-11-27
+
+### Added
+
+- Added support for additional status codes.
+
+### Changed
+
+## [1.0.0] - 2023-10-31
+
+### Added
+
+### Changed
+
+- GA release.
+
+## [0.6.3] - 2023-10-19
+
+### Added
+
+- Decoupled uri decoding logic used for Telemetry span naming from logic used for Parameter middleware
+
+## [0.6.2] - 2023-10-19
+
+### Added
+
+- Added support for providing custom client when creating with middleware.
+
+### Changed
+
+- Replace default transport with kiota transport when using custom client with proxy.
+
+## [0.6.1] - 2023-10-17
+
+### Changed
+
+- Ensures only URL query parameter names are decoded by `ParametersNameDecodingHandler`. [#207]
+
+## [0.6.0] - 2023-09-01
+
+### Added
+
+- Added support for continuous access evaluation.
+
+### Changed
+
+## [0.5.0] - 2023-07-27
+
+### Added
+
+- Added a translator method to change a `RequestInformation` object into a HTTPX client request object.
+- Enabled backing store support
+
+### Changed
+
+## [0.4.4] - 2023-05-31
+
+### Added
+
+- Added a url replace handler for replacing url segments.
+
+### Changed
+
+## [0.4.3] - 2023-05-16
+
+### Added
+
+### Changed
+
+- Fixes bug in getting content from redirected request.
+
+## [0.4.2] - 2023-05-02
+
+### Added
+
+### Changed
+
+- Includes Response headers in APIException for failed requests.
+
+## [0.4.1] - 2023-03-29
+
+### Added
+
+### Changed
+
+- Fixed bug with mapping when deserializing primitive response types.
+
+## [0.4.0] - 2023-02-06
+
+### Added
+
+- Added the HTTP response status code on APIError class.
+
+### Changed
+
+- Fixed bug with middleware not respecting request options.
+
+## [0.3.0] - 2023-01-20
+
+### Changed
+
+- Enabled configuring of middleware during client creation by passing custom options in call to create with default middleware. [#56](https://github.com/microsoft/kiota-http-python/issues/56)
+
+## [0.2.4] - 2023-01-17
+
+### Changed
+
+- Changes the ResponeHandler parameter in RequestAdapter to be a RequestOption

--- a/packages/http/httpx/README.md
+++ b/packages/http/httpx/README.md
@@ -1,6 +1,6 @@
 # Microsoft Kiota HTTP library
+
 [![PyPI version](https://badge.fury.io/py/microsoft-kiota-http.svg)](https://badge.fury.io/py/microsoft-kiota-http)
-[![CI Actions Status](https://github.com/microsoft/kiota-http-python/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/microsoft/kiota-http-python/actions)
 [![Downloads](https://pepy.tech/badge/microsoft-kiota-http)](https://pepy.tech/project/microsoft-kiota-http)
 
 The Microsoft Kiota HTTP Library is a python HTTP implementation with HTTPX library.
@@ -21,7 +21,7 @@ pip install microsoft-kiota-http
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
@@ -33,8 +33,8 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ## Trademarks
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft 
-trademarks or logos is subject to and must follow 
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
+trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.

--- a/packages/http/httpx/kiota_http/_version.py
+++ b/packages/http/httpx/kiota_http/_version.py
@@ -1,1 +1,3 @@
-VERSION: str = '1.3.3'
+import importlib.metadata
+
+VERSION: str = importlib.metadata.version('microsoft-kiota-http')

--- a/packages/http/httpx/pyproject.toml
+++ b/packages/http/httpx/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "microsoft-kiota-http"
-version = "0.0.7"
+version = "1.3.4"
 description = "Core abstractions for kiota generated libraries in Python"
 authors = ["Microsoft <graphtooling+python@microsoft.com>"]
 license = "MIT"

--- a/packages/serialization/form/CHANGELOG.md
+++ b/packages/serialization/form/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+### Changed
+
+## [0.1.1] - 2024-02-21
+
+### Added
+
+- Added a check to prevent form serialization from supporting nested
+
+### Removed
+
+- Removed a null check for keys during the serialization process.
+
+### Changed
+
+## [0.1.0] - 2024-02-21
+
+### Added
+
+- Added support for URI-form encoded serialization for Python.
+
+### Changed

--- a/packages/serialization/form/README.md
+++ b/packages/serialization/form/README.md
@@ -1,6 +1,6 @@
 # Microsoft Kiota URI Form Encoded Serialization Library for Python
+
 [![PyPI version](https://badge.fury.io/py/microsoft-kiota-serialization-form.svg)](https://badge.fury.io/py/microsoft-kiota-serialization-form)
-[![CI Actions Status](https://github.com/microsoft/kiota-serialization-form-python/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/microsoft/kiota-serialization-form-python/actions)
 [![Downloads](https://pepy.tech/badge/microsoft-kiota-serialization-form)](https://pepy.tech/project/microsoft-kiota-serialization-form)
 
 The Form Serialization Library for Python is the python `application/x-www-form-urlencoded` serialization library implementation.
@@ -21,7 +21,7 @@ pip install microsoft-kiota-serialization-form
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
@@ -33,8 +33,8 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ## Trademarks
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft 
-trademarks or logos is subject to and must follow 
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
+trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.

--- a/packages/serialization/form/kiota_serialization_form/_version.py
+++ b/packages/serialization/form/kiota_serialization_form/_version.py
@@ -1,1 +1,3 @@
-VERSION: str = '0.1.1'
+import importlib.metadata
+
+VERSION: str = importlib.metadata.version('microsoft-kiota-serialization-form')

--- a/packages/serialization/form/pyproject.toml
+++ b/packages/serialization/form/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "microsoft-kiota-serialization-form"
-version = "0.0.4"
+version = "1.3.4"
 description = "Core abstractions for kiota generated libraries in Python"
 authors = ["Microsoft <graphtooling+python@microsoft.com>"]
 license = "MIT"

--- a/packages/serialization/json/CHANGELOG.md
+++ b/packages/serialization/json/CHANGELOG.md
@@ -1,0 +1,167 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.3.3] - 2024-10-03
+
+### Fixed
+
+- Fixed an issue where `pendulum.DateTime` objects were not properly serialized by `JsonSerializationWriter`. Now, `pendulum.DateTime` objects are correctly recognized as subclasses of `datetime.datetime` and serialized accordingly.
+
+## [1.3.2] - 2024-09-10
+
+### Added
+
+- Fixed numeric strings from being parsed as Datetime objects to being parsed as strings.
+- Only parse to Datetime objects that conform to ISO 8601 format.
+
+## [1.3.1] - 2024-08-23
+
+### Added
+
+- Fixed 4-digit numeric strings from being parsed as Datetime objects to being parsed as strings.
+
+## [1.3.0] - 2024-07-26
+
+### Added
+
+- Support `dict[str, Any]` and `list[dict[str, Any]]` when writing additional data.
+
+### Changed
+
+- Fixed a bug where date time deserialization would fail because of empty strings.
+- Fixed a bug where float deserialization if the number represented qualified as an int.
+
+## [1.2.0] - 2024-04-09
+
+### Added
+
+### Changed
+
+- Enhanced error handling: Enabled silent failure when an enum key is not available
+
+## [1.1.0] - 2024-02-29
+
+### Added
+
+### Changed
+
+- Support objects and collections when writing additional data.
+
+## [1.0.1] - 2023-12-16
+
+### Added
+
+### Changed
+
+- Bump pendulum to v3.0.0b1 for python 3.12 support.
+
+## [1.0.0] - 2023-10-31
+
+### Added
+
+### Changed
+
+- GA release
+
+## [0.4.2] - 2023-10-11
+
+### Added
+
+### Changed
+
+- Switched from python-dateutil to pendulum for parsing datetime types.
+
+## [0.4.1] - 2023-09-21
+
+### Added
+
+### Changed
+
+- Allow passing of valid strings as values for datetime and UUID fields.
+
+## [0.4.0] - 2023-07-27
+
+### Added
+
+### Changed
+
+- Enabled backing store support
+
+## [0.3.7] - 2023-07-04
+
+### Added
+
+### Changed
+
+- Fixes the key assignment to the writer in write_bytes_value.
+
+## [0.3.6] - 2023-06-27
+
+### Added
+
+### Changed
+
+- Fixed a bug with loading json response in method to get root parse node.
+
+## [0.3.5] - 2023-06-14
+
+### Added
+
+- Added support for composed types (de)serialization.
+
+### Changed
+
+- Fixed a bug with assigning field values.
+
+## [0.3.4] - 2023-05-17
+
+### Added
+
+### Changed
+
+- Fixed a bug with assigning field values.
+
+## [0.3.3] - 2023-04-27
+
+### Added
+
+### Changed
+
+- Fixed a bug with deserializing collection of enum values.
+
+## [0.3.2] - 2023-04-27
+
+### Added
+
+### Changed
+
+- Fixed a bug with deserializing models with additional data.
+
+## [0.3.1] - 2023-03-20
+
+### Added
+
+### Changed
+
+- Fixed a bug with deserializing bytes responses.
+
+## [0.3.0] - 2023-03-09
+
+### Added
+
+### Changed
+
+- Switched from snake casing api response keys to prevent mismatch scenarios.
+- Fixed a bug with getting child node using deserializer identifier
+
+## [0.2.2] - 2023-02-21
+
+### Added
+
+### Changed
+
+- Fixed a bug with deserializing 'None' string values in enums.

--- a/packages/serialization/json/README.md
+++ b/packages/serialization/json/README.md
@@ -1,6 +1,6 @@
 # Microsoft Kiota Serialization library for JSON
+
 [![PyPI version](https://badge.fury.io/py/microsoft-kiota-serialization-json.svg)](https://badge.fury.io/py/microsoft-kiota-serialization-json)
-[![CI Actions Status](https://github.com/microsoft/kiota-serialization-json-python/actions/workflows/build_publish.yml/badge.svg?branch=main)](https://github.com/microsoft/kiota-serialization-json-python/actions)
 [![Downloads](https://pepy.tech/badge/microsoft-kiota-serialization-json)](https://pepy.tech/project/microsoft-kiota-serialization-json)
 
 The Microsoft Kiota Serialization Library for JSON is a python implementation to serialize/deserialize JSON.
@@ -21,7 +21,7 @@ pip install microsoft-kiota-serialization-json
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
@@ -33,8 +33,8 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ## Trademarks
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft 
-trademarks or logos is subject to and must follow 
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
+trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.

--- a/packages/serialization/json/kiota_serialization_json/_version.py
+++ b/packages/serialization/json/kiota_serialization_json/_version.py
@@ -1,1 +1,3 @@
-VERSION: str = '1.3.1'
+import importlib.metadata
+
+VERSION: str = importlib.metadata.version('microsoft-kiota-serialization-json')

--- a/packages/serialization/json/pyproject.toml
+++ b/packages/serialization/json/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "microsoft-kiota-serialization-json"
-version = "0.0.4"
+version = "1.3.4"
 description = "Core abstractions for kiota generated libraries in Python"
 authors = ["Microsoft <graphtooling+python@microsoft.com>"]
 license = "MIT"

--- a/packages/serialization/multipart/CHANGELOG.md
+++ b/packages/serialization/multipart/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+### Changed
+
+## [0.1.0] - 2024-02-27
+
+### Added
+
+- Added support for multipart serialization for Python.[microsoft/kiota#3030](https://github.com/microsoft/kiota/issues/3030)
+
+### Changed

--- a/packages/serialization/multipart/README.md
+++ b/packages/serialization/multipart/README.md
@@ -1,6 +1,6 @@
 # Microsoft Kiota Multipart Serialization Library for Python
+
 [![PyPI version](https://badge.fury.io/py/microsoft-kiota-serialization-multipart.svg)](https://badge.fury.io/py/microsoft-kiota-serialization-multipart)
-[![CI Actions Status](https://github.com/microsoft/kiota-serialization-multipart-python/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/microsoft/kiota-serialization-multipart-python/actions)
 [![Downloads](https://pepy.tech/badge/microsoft-kiota-serialization-multipart)](https://pepy.tech/project/microsoft-kiota-serialization-multipart)
 
 The Multipart Serialization Library for Python is the python `multipart/form-data` serialization library implementation.
@@ -21,7 +21,7 @@ pip install microsoft-kiota-serialization-multipart
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
@@ -33,8 +33,8 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ## Trademarks
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft 
-trademarks or logos is subject to and must follow 
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
+trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.

--- a/packages/serialization/multipart/kiota_serialization_multipart/_version.py
+++ b/packages/serialization/multipart/kiota_serialization_multipart/_version.py
@@ -1,1 +1,3 @@
-VERSION: str = '0.1.0'
+import importlib.metadata
+
+VERSION: str = importlib.metadata.version('microsoft-kiota-serialization-multipart')

--- a/packages/serialization/multipart/pyproject.toml
+++ b/packages/serialization/multipart/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "microsoft-kiota-serialization-multipart"
-version = "0.0.4"
+version = "1.3.4"
 description = "Core abstractions for kiota generated libraries in Python"
 authors = ["Microsoft <graphtooling+python@microsoft.com>"]
 license = "MIT"

--- a/packages/serialization/text/CHANGELOG.md
+++ b/packages/serialization/text/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2023-10-31
+
+### Added
+
+### Changed
+
+- GA release.
+
+## [0.3.0] - 2023-10-19
+
+### Added
+
+### Changed
+
+- Changed serialization callback methods to properties.
+
+## [0.2.1] - 2023-06-14
+
+### Added
+
+- Added support for composed types serialization.
+
+### Changed
+
+- Changed writer from array to string to prevent writing of multiple values.
+- Fixed bug with serializing enums.

--- a/packages/serialization/text/README.md
+++ b/packages/serialization/text/README.md
@@ -1,6 +1,6 @@
 # Microsoft Kiota Text Serialization library
+
 [![PyPI version](https://badge.fury.io/py/microsoft-kiota-serialization-text.svg)](https://badge.fury.io/py/microsoft-kiota-serialization-text)
-[![CI Actions Status](https://github.com/microsoft/kiota-serialization-text-python/actions/workflows/build_publish.yml/badge.svg?branch=main)](https://github.com/microsoft/kiota-serialization-text-python/actions)
 [![Downloads](https://pepy.tech/badge/microsoft-kiota-serialization-text)](https://pepy.tech/project/microsoft-kiota-serialization-text)
 
 The Microsoft Kiota Text Serialization Library is a python implementation to serialize/deserialize text/plain.
@@ -21,7 +21,7 @@ pip install microsoft-kiota-serialization-text
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
@@ -33,8 +33,8 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ## Trademarks
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft 
-trademarks or logos is subject to and must follow 
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
+trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.

--- a/packages/serialization/text/kiota_serialization_text/_version.py
+++ b/packages/serialization/text/kiota_serialization_text/_version.py
@@ -1,1 +1,3 @@
-VERSION: str = '1.0.0'
+import importlib.metadata
+
+VERSION: str = importlib.metadata.version('microsoft-kiota-serialization-text')

--- a/packages/serialization/text/pyproject.toml
+++ b/packages/serialization/text/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "microsoft-kiota-serialization-text"
-version = "0.0.4"
+version = "1.3.4"
 description = "Core abstractions for kiota generated libraries in Python"
 authors = ["Microsoft <graphtooling+python@microsoft.com>"]
 license = "MIT"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,97 @@
+{
+  "exclude-paths": [".git", ".idea", ".github", ".vscode"],
+  "include-component-in-tag": false,
+  "include-v-in-tag": true,
+  "separate-pull-requests": false,
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
+  "versioning": "prerelease",
+  "bootstrap-sha": "1f879d73ac30a7f098323468e32d33e165f7f229",
+  "packages": {
+    "packages/abstractions": {
+      "component": "microsoft-kiota-abstractions",
+      "release-type": "simple",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "pyproject.toml",
+          "jsonpath": "$.tool.poetry.version"
+        }
+      ]
+    },
+    "packages/authentication/azure": {
+      "component": "microsoft-kiota-authentication-azure",
+      "release-type": "simple",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "pyproject.toml",
+          "jsonpath": "$.tool.poetry.version"
+        }
+      ]
+    },
+    "packages/http/httpx": {
+      "component": "microsoft-kiota-http",
+      "release-type": "simple",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "pyproject.toml",
+          "jsonpath": "$.tool.poetry.version"
+        }
+      ]
+    },
+    "packages/serialization/json": {
+      "component": "microsoft-kiota-serialization-json",
+      "release-type": "simple",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "pyproject.toml",
+          "jsonpath": "$.tool.poetry.version"
+        }
+      ]
+    },
+    "packages/serialization/form": {
+      "component": "microsoft-kiota-serialization-form",
+      "release-type": "simple",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "pyproject.toml",
+          "jsonpath": "$.tool.poetry.version"
+        }
+      ]
+    },
+    "packages/serialization/text": {
+      "component": "microsoft-kiota-serialization-text",
+      "release-type": "simple",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "pyproject.toml",
+          "jsonpath": "$.tool.poetry.version"
+        }
+      ]
+    },
+    "packages/serialization/multipart": {
+      "component": "microsoft-kiota-serialization-multipart",
+      "release-type": "simple",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "pyproject.toml",
+          "jsonpath": "$.tool.poetry.version"
+        }
+      ]
+    }
+  },
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
+}

--- a/tests/validation/pyproject.toml
+++ b/tests/validation/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "validation-client"
-version = "0.0.4"
+version = "1.3.4"
 description = "Core abstractions for kiota generated libraries in Python"
 authors = ["Microsoft <graphtooling+python@microsoft.com>"]
 license = "MIT"


### PR DESCRIPTION
Fixes https://github.com/microsoft/kiota-abstractions-python/issues/174

- Sets up release please for merged repository. 
- Migrates changelogs from individual library repositories.
- Updates source to read version from toml rather that being hand set in `_version.py` files in various projects.
- Sets all project versions to 1.3.4 to be the highest for the next release.

