### PR TITLE
fix(json): remove redundant guard in get_child_node

### DIFF
--- a/packages/serialization/json/kiota_serialization_json/json_parse_node.py
+++ b/packages/serialization/json/kiota_serialization_json/json_parse_node.py
@@ -42,9 +42,6 @@ class JsonParseNode(ParseNode):
         Returns:
             Optional[ParseNode]: A new parse node for the given identifier
         """
-        if not identifier:
-            raise ValueError("identifier cannot be None or empty.")
-
         if isinstance(node := self._json_node, dict) and identifier in node:
             return self._create_new_node(node[identifier])
         return None

--- a/packages/serialization/json/tests/unit/test_json_parse_node.py
+++ b/packages/serialization/json/tests/unit/test_json_parse_node.py
@@ -35,6 +35,19 @@ def test_get_float_value_from_float():
     assert result == 44.6
 
 
+def test_get_child_node_not_found():
+    parse_node = JsonParseNode({"name": "Diego Siciliani"})
+    result = parse_node.get_child_node("age")
+    assert result is None
+
+
+def test_get_child_node_empty_name():
+    parse_node = JsonParseNode({"": "Diego Siciliani"})
+    result = parse_node.get_child_node("")
+    assert result is not None
+    assert result.get_str_value() == "Diego Siciliani"
+
+
 @pytest.mark.parametrize("value", [0, 10, 100])
 def test_get_float_value(value: int):
     """

--- a/packages/serialization/json/tests/unit/test_json_parse_node.py
+++ b/packages/serialization/json/tests/unit/test_json_parse_node.py
@@ -36,16 +36,16 @@ def test_get_float_value_from_float():
 
 
 def test_get_child_node_not_found():
-    parse_node = JsonParseNode({"name": "Diego Siciliani"})
+    parse_node = JsonParseNode({"name": "Jane Smith"})
     result = parse_node.get_child_node("age")
     assert result is None
 
 
 def test_get_child_node_empty_name():
-    parse_node = JsonParseNode({"": "Diego Siciliani"})
+    parse_node = JsonParseNode({"": "John Smith"})
     result = parse_node.get_child_node("")
     assert result is not None
-    assert result.get_str_value() == "Diego Siciliani"
+    assert result.get_str_value() == "John Smith"
 
 
 @pytest.mark.parametrize("value", [0, 10, 100])


### PR DESCRIPTION
## Overview

Removes an identified guard in `get_child_node`. The guard does not really protect from anything, but breaks generated code, for example in cases of `oneOf` without discriminator (see [`microsoft/kiota#6868`](https://github.com/microsoft/kiota/issues/6868)).

The method now returns `None`, which is allowed since the return type is `Optional[ParseNode]`.

## Related Issue

Fixes #559 