### PR TITLE
fix(json): base64-decode bytes values on deserialization

### DIFF
--- a/packages/serialization/json/kiota_serialization_json/json_parse_node.py
+++ b/packages/serialization/json/kiota_serialization_json/json_parse_node.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import json
 import re
 import warnings
@@ -290,15 +291,9 @@ class JsonParseNode(ParseNode):
 
     @staticmethod
     def _get_bytes_value(value: Any) -> Optional[bytes]:
-        # if the node is a string, we need to decode it
-        # This ensures that the string is properly converted to bytes
         if isinstance(value, str):
-            base64_string = value
-        else:
-            base64_string = json.dumps(value)
-        if not base64_string:
-            return None
-        return base64_string.encode("utf-8")
+            return base64.b64decode(value)
+        return None
 
     @property
     def on_before_assign_field_values(self) -> Optional[Callable[[Parsable], None]]:

--- a/packages/serialization/json/tests/unit/test_json_parse_node.py
+++ b/packages/serialization/json/tests/unit/test_json_parse_node.py
@@ -1,3 +1,4 @@
+import base64
 import json
 from datetime import date, datetime, time, timedelta, timezone
 from uuid import UUID
@@ -120,14 +121,19 @@ def test_get_collection_of_primitive_values_no_type():
 def test_get_bytes_value():
     parse_node = JsonParseNode("U2Ftd2VsIGlzIHRoZSBiZXN0")
     result = parse_node.get_bytes_value()
-    assert isinstance(result, bytes)
-    assert result.decode("utf-8") == "U2Ftd2VsIGlzIHRoZSBiZXN0"
+    assert result == b"Samwel is the best"
 
 
-def test_get_bytes_json_compatible():
+def test_get_bytes_value_empty_string():
+    parse_node = JsonParseNode("")
+    result = parse_node.get_bytes_value()
+    assert result == b""
+
+
+def test_get_bytes_value_non_string_returns_none():
     parse_node = JsonParseNode({"test": 1})
     result = parse_node.get_bytes_value()
-    assert json.loads(result.decode("utf-8")) == {"test": 1}
+    assert result is None
 
 
 def test_get_collection_of_enum_values():

--- a/packages/serialization/json/tests/unit/test_json_parse_node.py
+++ b/packages/serialization/json/tests/unit/test_json_parse_node.py
@@ -1,4 +1,3 @@
-import base64
 import json
 from datetime import date, datetime, time, timedelta, timezone
 from uuid import UUID


### PR DESCRIPTION
## Overview

`JsonParseNode.get_bytes_value()` was returning the raw base64 string re-encoded as UTF-8 bytes instead of decoding it. So any `Edm.Binary` property from Microsoft Graph (like `fileAttachment.contentBytes`) would come back as the base64 text in bytes form rather than the actual file data. The serialization writer already uses `base64.b64encode` correctly, so the reader wasn't matching it.

The fix replaces the broken body with `base64.b64decode(value)` for string inputs and `None` for non-strings. This mirrors how the text-format parse node handles the same field.

## Related Issue

Fixes #636

## Testing Instructions

- `cd packages/serialization/json`
- `pip install -e ".[dev]"` (or `poetry install`) if not already set up
- Run the bytes-specific tests: `pytest tests/unit/test_json_parse_node.py -k bytes -v`
- All three tests should pass: `test_get_bytes_value`, `test_get_bytes_value_empty_string`, and `test_get_bytes_value_non_string_returns_none`
- Full suite: `pytest` (89 tests, all pass)

### Notes

Thanks to @RockyMM for the detailed bug report, precise code location, and suggested fix in #636. This PR implements exactly that approach.