### PR TITLE
ci(dependabot): add cooldown default delay

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,26 +2,28 @@ version: 2
 updates:
 - package-ecosystem: pip
   directories:
-    - "/packages/abstractions"
-    - "/packages/serialization/form"
-    - "/packages/serialization/json"
-    - "/packages/serialization/text"
-    - "/packages/serialization/multipart"
-    - "/packages/authentication/azure"
-    - "/packages/http/httpx"
+  - /packages/abstractions
+  - /packages/serialization/form
+  - /packages/serialization/json
+  - /packages/serialization/text
+  - /packages/serialization/multipart
+  - /packages/authentication/azure
+  - /packages/http/httpx
   schedule:
     interval: daily
   open-pull-requests-limit: 10
   groups:
     open-telemetry:
       patterns:
-        - "*opentelemetry*"
+      - '*opentelemetry*'
     pylint:
       patterns:
-        - "*pylint*"
-        - "*astroid*"
+      - '*pylint*'
+      - '*astroid*'
+  cooldown:
+    default-days: 7
 - package-ecosystem: github-actions
-  directory: "/"
+  directory: /
   schedule:
     interval: daily
   open-pull-requests-limit: 10


### PR DESCRIPTION
Adds a 7-day default Dependabot cooldown so CIF deployment has time to complete before dependency update PRs are opened.

This helps avoid getting ahead with versions before they are fully available through deployment.